### PR TITLE
Fix/mobile responsive issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - run: npm ci
+
+      - run: npm run lint
+
+      - run: npm run build

--- a/src/app/dashboard/admin/settlements/page.tsx
+++ b/src/app/dashboard/admin/settlements/page.tsx
@@ -210,7 +210,58 @@ export default function AdminSettlementsPage() {
 
       {/* Settlements Table */}
       <div className="bg-white rounded-lg border border-gray-200 overflow-hidden">
-        <div className="overflow-x-auto">
+        {/* Mobile card layout */}
+        <div className="md:hidden divide-y divide-gray-200">
+          {loading ? (
+            <div className="px-4 py-8 text-center text-gray-500">Loading settlements...</div>
+          ) : settlements.length === 0 ? (
+            <div className="px-4 py-8 text-center text-gray-500">No settlements found</div>
+          ) : (
+            settlements.map((settlement) => {
+              const StatusIcon = statusIcons[settlement.status];
+              return (
+                <div key={settlement.id} className="px-4 py-3 space-y-1">
+                  <div className="flex items-center justify-between">
+                    <span className="text-sm font-medium text-gray-900">{settlement.id.slice(0, 8)}...</span>
+                    <span className={`inline-flex items-center gap-1 px-2 py-1 rounded-full text-xs font-medium ${statusColors[settlement.status]}`}>
+                      <StatusIcon className="w-3 h-3" />
+                      {settlement.status.replace('_', ' ')}
+                    </span>
+                  </div>
+                  <div className="text-sm text-gray-900">{settlement.merchant?.businessName || 'Unknown'}</div>
+                  <div className="text-sm font-medium text-gray-900">{formatCurrency(settlement.netAmountUsd)}</div>
+                  <div className="text-xs text-gray-500">Fee: {formatCurrency(settlement.feeAmountUsd)}</div>
+                  <div className="text-xs text-gray-500">{formatDate(settlement.createdAt)}</div>
+                  {settlement.failureReason && (
+                    <div className="text-xs text-red-600">{settlement.failureReason}</div>
+                  )}
+                  <div className="flex items-center gap-2 pt-1">
+                    {settlement.status === 'failed' && (
+                      <button
+                        onClick={() => handleRetry(settlement.id)}
+                        disabled={actionLoading === settlement.id}
+                        className="px-2 py-1 text-xs bg-blue-100 text-blue-700 rounded hover:bg-blue-200 disabled:opacity-50"
+                      >
+                        {actionLoading === settlement.id ? 'Retrying...' : 'Retry'}
+                      </button>
+                    )}
+                    {settlement.status === 'pending_approval' && (
+                      <button
+                        onClick={() => handleApprove(settlement.id)}
+                        disabled={actionLoading === settlement.id}
+                        className="px-2 py-1 text-xs bg-green-100 text-green-700 rounded hover:bg-green-200 disabled:opacity-50"
+                      >
+                        {actionLoading === settlement.id ? 'Approving...' : 'Approve'}
+                      </button>
+                    )}
+                  </div>
+                </div>
+              );
+            })
+          )}
+        </div>
+
+        <div className="hidden md:block overflow-x-auto">
           <table className="w-full">
             <thead className="bg-gray-50 border-b border-gray-200">
               <tr>

--- a/src/app/dashboard/analytics/page.tsx
+++ b/src/app/dashboard/analytics/page.tsx
@@ -35,7 +35,7 @@ export default function AnalyticsPage() {
         <div className="text-center py-12 text-gray-400">Loading...</div>
       ) : (
         <div className="space-y-6">
-          <div className="grid grid-cols-2 gap-4">
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
             <div className="card p-6">
               <p className="text-sm text-gray-500 mb-1">Total Volume</p>
               <p className="text-3xl font-bold">{formatUsd(totalVolume)}</p>

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import { usePathname, useRouter } from 'next/navigation';
 import {
@@ -11,6 +11,8 @@ import {
   LogOut,
   Webhook,
   BarChart3,
+  Menu,
+  X,
 } from 'lucide-react';
 import { useAuthStore } from '@/lib/store';
 import { cn } from '@/lib/utils';
@@ -28,56 +30,101 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
   const { merchant, token, logout } = useAuthStore();
   const router = useRouter();
   const pathname = usePathname();
+  const [mobileNavOpen, setMobileNavOpen] = useState(false);
 
   useEffect(() => {
     if (!token) router.push('/auth/login');
   }, [token, router]);
 
+  useEffect(() => {
+    setMobileNavOpen(false);
+  }, [pathname]);
+
   if (!merchant) return null;
 
-  return (
-    <div className="min-h-screen flex bg-gray-50">
-      {/* Sidebar */}
-      <aside className="w-64 bg-white border-r border-gray-200 flex flex-col">
-        <div className="p-6 border-b border-gray-100">
+  const sidebarContent = (
+    <>
+      <div className="p-6 border-b border-gray-100 flex items-center justify-between">
+        <div>
           <span className="font-bold text-brand-600 text-lg">DupDub</span>
           <p className="text-xs text-gray-500 mt-1 truncate">{merchant.businessName}</p>
         </div>
+        <button
+          onClick={() => setMobileNavOpen(false)}
+          className="md:hidden text-gray-400 hover:text-gray-600"
+          aria-label="Close menu"
+        >
+          <X className="w-5 h-5" />
+        </button>
+      </div>
 
-        <nav className="flex-1 p-4 space-y-1">
-          {navItems.map(({ href, label, icon: Icon, exact }) => {
-            const active = exact ? pathname === href : pathname.startsWith(href);
-            return (
-              <Link
-                key={href}
-                href={href}
-                className={cn(
-                  'flex items-center gap-3 px-3 py-2 rounded-lg text-sm font-medium transition-colors',
-                  active
-                    ? 'bg-brand-50 text-brand-700'
-                    : 'text-gray-600 hover:bg-gray-50 hover:text-gray-900',
-                )}
-              >
-                <Icon className="w-4 h-4" />
-                {label}
-              </Link>
-            );
-          })}
-        </nav>
+      <nav className="flex-1 p-4 space-y-1">
+        {navItems.map(({ href, label, icon: Icon, exact }) => {
+          const active = exact ? pathname === href : pathname.startsWith(href);
+          return (
+            <Link
+              key={href}
+              href={href}
+              className={cn(
+                'flex items-center gap-3 px-3 py-2 rounded-lg text-sm font-medium transition-colors',
+                active
+                  ? 'bg-brand-50 text-brand-700'
+                  : 'text-gray-600 hover:bg-gray-50 hover:text-gray-900',
+              )}
+            >
+              <Icon className="w-4 h-4" />
+              {label}
+            </Link>
+          );
+        })}
+      </nav>
 
-        <div className="p-4 border-t border-gray-100">
-          <button
-            onClick={() => { logout(); router.push('/auth/login'); }}
-            className="flex items-center gap-3 px-3 py-2 text-sm text-gray-500 hover:text-gray-900 w-full rounded-lg hover:bg-gray-50 transition-colors"
-          >
-            <LogOut className="w-4 h-4" />
-            Sign out
-          </button>
-        </div>
+      <div className="p-4 border-t border-gray-100">
+        <button
+          onClick={() => { logout(); router.push('/auth/login'); }}
+          className="flex items-center gap-3 px-3 py-2 text-sm text-gray-500 hover:text-gray-900 w-full rounded-lg hover:bg-gray-50 transition-colors"
+        >
+          <LogOut className="w-4 h-4" />
+          Sign out
+        </button>
+      </div>
+    </>
+  );
+
+  return (
+    <div className="min-h-screen flex bg-gray-50">
+      {/* Mobile top bar */}
+      <div className="md:hidden fixed top-0 inset-x-0 h-14 bg-white border-b border-gray-200 flex items-center px-4 z-30">
+        <button
+          onClick={() => setMobileNavOpen(true)}
+          className="text-gray-500 hover:text-gray-900"
+          aria-label="Open menu"
+        >
+          <Menu className="w-6 h-6" />
+        </button>
+        <span className="font-bold text-brand-600 text-lg ml-3">DupDub</span>
+      </div>
+
+      {/* Sidebar - desktop */}
+      <aside className="hidden md:flex w-64 bg-white border-r border-gray-200 flex-col">
+        {sidebarContent}
       </aside>
 
+      {/* Sidebar - mobile off-canvas drawer */}
+      {mobileNavOpen && (
+        <div className="md:hidden fixed inset-0 z-40 flex">
+          <div
+            className="fixed inset-0 bg-black/40"
+            onClick={() => setMobileNavOpen(false)}
+          />
+          <aside className="relative w-64 bg-white border-r border-gray-200 flex flex-col">
+            {sidebarContent}
+          </aside>
+        </div>
+      )}
+
       {/* Main */}
-      <main className="flex-1 overflow-auto">{children}</main>
+      <main className="flex-1 overflow-auto pt-14 md:pt-0">{children}</main>
     </div>
   );
 }

--- a/src/app/dashboard/payments/page.tsx
+++ b/src/app/dashboard/payments/page.tsx
@@ -137,7 +137,34 @@ export default function PaymentsPage() {
 
       {/* Payments Table */}
       <div className="card">
-        <div className="overflow-x-auto">
+        {/* Mobile card layout */}
+        <div className="md:hidden divide-y divide-gray-50">
+          {loading ? (
+            <div className="px-6 py-8 text-center text-gray-400">Loading...</div>
+          ) : payments.length === 0 ? (
+            <div className="px-6 py-8 text-center text-gray-400">No payments yet</div>
+          ) : (
+            payments.map((p) => (
+              <div key={p.id} className="px-6 py-4 space-y-1">
+                <div className="flex items-center justify-between">
+                  <span className="font-mono text-xs text-gray-500">{p.reference}</span>
+                  <span className={`text-xs px-2 py-0.5 rounded-full font-medium ${PAYMENT_STATUS_COLORS[p.status]}`}>
+                    {p.status}
+                  </span>
+                </div>
+                <div className="font-semibold">{formatUsd(p.amountUsd)}</div>
+                <div className="text-xs text-gray-500">{formatDate(p.createdAt)}</div>
+                {p.status === 'pending' && (
+                  <button onClick={() => setSelectedPayment(p)} className="text-brand-600 text-xs hover:underline">
+                    Show QR
+                  </button>
+                )}
+              </div>
+            ))
+          )}
+        </div>
+
+        <div className="hidden md:block overflow-x-auto">
           <table className="w-full text-sm">
             <thead className="bg-gray-50 border-b border-gray-100">
               <tr>

--- a/src/app/dashboard/settlements/page.tsx
+++ b/src/app/dashboard/settlements/page.tsx
@@ -32,7 +32,32 @@ export default function SettlementsPage() {
       </div>
 
       <div className="card">
-        <div className="overflow-x-auto">
+        {/* Mobile card layout */}
+        <div className="md:hidden divide-y divide-gray-50">
+          {loading ? (
+            <div className="px-6 py-8 text-center text-gray-400">Loading...</div>
+          ) : settlements.length === 0 ? (
+            <div className="px-6 py-8 text-center text-gray-400">No settlements yet</div>
+          ) : (
+            settlements.map((s) => (
+              <div key={s.id} className="px-6 py-4 space-y-1">
+                <div className="flex items-center justify-between">
+                  <span className="font-mono text-xs text-gray-500">{s.id.slice(0, 8)}...</span>
+                  <span className={`text-xs px-2 py-0.5 rounded-full font-medium ${STATUS_COLORS[s.status]}`}>
+                    {s.status}
+                  </span>
+                </div>
+                <div className="font-semibold text-green-700">{formatUsd(s.netAmountUsd)}</div>
+                <div className="text-xs text-gray-500">
+                  Gross {formatUsd(s.totalAmountUsd)} · Fee -{formatUsd(s.feeAmountUsd)}
+                </div>
+                <div className="text-xs text-gray-500">{formatDate(s.createdAt)}</div>
+              </div>
+            ))
+          )}
+        </div>
+
+        <div className="hidden md:block overflow-x-auto">
           <table className="w-full text-sm">
             <thead className="bg-gray-50 border-b border-gray-100">
               <tr>


### PR DESCRIPTION
closes #235
closes #236
closes #237
closes #238

Problem
In src/app/dashboard/analytics/page.tsx, the two summary cards ("Total Volume", "Total Transactions") use className="grid grid-cols-2 gap-4" with no responsive override — unlike other pages in the app that consistently use md:/lg: breakpoint prefixes (e.g., the dashboard overview's grid-cols-1 md:grid-cols-4).
On mobile, merchants (and admins) must scroll horizontally to see every column of every row, a well-known usability pain point for data tables on small screens, especially combined with the already-cramped sidebar (see related report).
Broken builds, lint failures, and (once added) failing tests can be merged to the main branch with nothing catching them automatically; code review is the only quality gate today.
On phone-width screens, the fixed 256px sidebar consumes a large fraction of the available width, squeezing the main content (tables, forms, charts) into an uncomfortably narrow column with no alternate mobile navigation.

