### PR TITLE
Fix/jobsunday002 issues

### DIFF
--- a/src/app/auth/login/layout.tsx
+++ b/src/app/auth/login/layout.tsx
@@ -1,0 +1,10 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Sign in — DupDub',
+  robots: { index: false },
+};
+
+export default function LoginLayout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/src/app/auth/register/layout.tsx
+++ b/src/app/auth/register/layout.tsx
@@ -1,0 +1,10 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Create account — DupDub',
+  robots: { index: false },
+};
+
+export default function RegisterLayout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,4 @@
-import type { Metadata } from 'next';
+import type { Metadata, Viewport } from 'next';
 import { Inter } from 'next/font/google';
 import { Toaster } from 'react-hot-toast';
 import './globals.css';
@@ -8,6 +8,24 @@ const inter = Inter({ subsets: ['latin'] });
 export const metadata: Metadata = {
   title: 'DupDub — Crypto-to-Fiat Settlement',
   description: 'Accept crypto payments, receive fiat settlements instantly',
+  openGraph: {
+    title: 'DupDub — Crypto-to-Fiat Settlement',
+    description: 'Accept crypto payments, receive fiat settlements instantly',
+    images: ['/og-image.png'],
+    type: 'website',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'DupDub — Crypto-to-Fiat Settlement',
+    description: 'Accept crypto payments, receive fiat settlements instantly',
+    images: ['/og-image.png'],
+  },
+};
+
+export const viewport: Viewport = {
+  width: 'device-width',
+  initialScale: 1,
+  themeColor: '#ffffff',
 };
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,9 +1,35 @@
+import type { Metadata } from 'next';
 import Link from 'next/link';
 import { ArrowRight, Zap, Shield, Globe, QrCode } from 'lucide-react';
+
+export const metadata: Metadata = {
+  title: 'DupDub — Accept Crypto, Receive Fiat Instantly',
+  description:
+    'DupDub bridges Web3 payments with traditional banking. Merchants receive NGN/USD settlements while customers pay with USDC on Stellar.',
+  openGraph: {
+    title: 'DupDub — Accept Crypto, Receive Fiat Instantly',
+    description:
+      'DupDub bridges Web3 payments with traditional banking. Merchants receive NGN/USD settlements while customers pay with USDC on Stellar.',
+    images: ['/og-image.png'],
+    type: 'website',
+  },
+};
+
+const jsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'Organization',
+  name: 'DupDub',
+  description: 'Crypto-to-fiat settlement platform bridging Web3 payments with traditional banking.',
+  url: 'https://dupdub.com',
+};
 
 export default function LandingPage() {
   return (
     <div className="min-h-screen bg-white">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
       {/* Nav */}
       <nav className="border-b border-gray-100">
         <div className="max-w-6xl mx-auto px-6 h-16 flex items-center justify-between">

--- a/src/app/pay/[paymentId]/page.tsx
+++ b/src/app/pay/[paymentId]/page.tsx
@@ -55,19 +55,19 @@ export default function PayPage({ params }: { params: { paymentId: string } }) {
 
   return (
     <div className="min-h-screen bg-gray-50 flex items-center justify-center p-4">
-      <div className="card w-full max-w-sm">
-        <div className="p-6 border-b border-gray-100 text-center">
+      <div className="card w-full max-w-[92vw] xs:max-w-sm">
+        <div className="p-4 xs:p-6 border-b border-gray-100 text-center">
           <p className="text-sm text-gray-500 font-medium">DupDub</p>
           <h1 className="text-3xl font-bold mt-1">{formatUsd(payment.amountUsd)}</h1>
           {payment.description && <p className="text-sm text-gray-500 mt-1">{payment.description}</p>}
         </div>
 
-        <div className="p-6">
+        <div className="p-4 xs:p-6">
           {payment.status === 'pending' ? (
             <>
               <div className="flex justify-center mb-4">
                 <div className="bg-white p-3 rounded-xl border border-gray-200">
-                  <QRCodeSVG value={stellarUri} size={180} />
+                  <QRCodeSVG value={stellarUri} size={160} />
                 </div>
               </div>
               <p className="text-center text-xs text-gray-500 mb-4">


### PR DESCRIPTION
closes #239
closes #240 
closes #241 
closes #242
Problem
src/app/auth/login/page.tsx and src/app/auth/register/page.tsx export no route-level metadata — both inherit the generic root title, and neither sets robots: { index: false } despite being non-content, non-shareable app pages.

Impact
Search engines may index /auth/login and /auth/register under the same generic marketing title/description as the homepage, diluting search relevan

Problem
src/app/pay/[paymentId]/page.tsx uses a fixed max-w-sm card containing a size={180} QR code with p-6 padding, with no responsive adjustment or explicit testing noted for very small viewports (e.g., 320px-wide devices).

Impact
On the smallest common phone widths, the combination of fixed QR size plus padding could leave little margin, and there's no verification this checkout-critical page has been tested at that breakpoint — a cramped or clipped layout here directly risks a failed/abandoned customer payment.

