### PR TITLE
Fix/waitlist dashboard pay metadata

### DIFF
--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -15,6 +15,10 @@ import {
 import { useAuthStore } from '@/lib/store';
 import { cn } from '@/lib/utils';
 
+export const metadata = {
+  robots: { index: false, follow: false },
+};
+
 const navItems = [
   { href: '/dashboard', label: 'Overview', icon: LayoutDashboard, exact: true },
   { href: '/dashboard/payments', label: 'Payments', icon: CreditCard },

--- a/src/app/dashboard/settings/page.tsx
+++ b/src/app/dashboard/settings/page.tsx
@@ -70,13 +70,15 @@ export default function SettingsPage() {
             { key: 'businessName', label: 'Business Name' },
             { key: 'country', label: 'Country' },
             { key: 'bankName', label: 'Bank Name' },
-            { key: 'bankCode', label: 'Bank Code' },
-            { key: 'bankAccountNumber', label: 'Bank Account Number' },
-          ].map(({ key, label }) => (
+            { key: 'bankCode', label: 'Bank Code', inputMode: 'numeric' as const, pattern: '[0-9]{3,6}' },
+            { key: 'bankAccountNumber', label: 'Bank Account Number', inputMode: 'numeric' as const, pattern: '[0-9]{6,17}' },
+          ].map(({ key, label, inputMode, pattern }) => (
             <div key={key}>
               <label className="label">{label}</label>
               <input
                 className="input"
+                inputMode={inputMode}
+                pattern={pattern}
                 value={form[key as keyof typeof form]}
                 onChange={(e) => setForm({ ...form, [key]: e.target.value })}
               />

--- a/src/app/pay/[paymentId]/page.tsx
+++ b/src/app/pay/[paymentId]/page.tsx
@@ -6,6 +6,15 @@ import { Clock, CheckCircle, XCircle, Loader2 } from 'lucide-react';
 import { paymentsApi } from '@/lib/api';
 import { formatUsd } from '@/lib/utils';
 
+export async function generateMetadata({ params }: { params: { paymentId: string } }) {
+  try {
+    const { data } = await paymentsApi.getByReference(params.paymentId);
+    return { title: `Pay ${formatUsd(data.amountUsd)} — DupDub` };
+  } catch {
+    return { title: 'Pay — DupDub' };
+  }
+}
+
 const STATUS_ICONS: Record<string, React.ReactNode> = {
   pending: <Clock className="w-8 h-8 text-yellow-500" />,
   confirmed: <Loader2 className="w-8 h-8 text-blue-500 animate-spin" />,

--- a/src/app/waitlist/page.tsx
+++ b/src/app/waitlist/page.tsx
@@ -6,6 +6,11 @@ import toast from 'react-hot-toast';
 import { CheckCircle } from 'lucide-react';
 import { waitlistApi } from '@/lib/api';
 
+export const metadata = {
+  title: 'Join the waitlist — DupDub',
+  description: 'Be first to access DupDub when we launch — join the waitlist today.',
+};
+
 export default function WaitlistPage() {
   const [form, setForm] = useState({ email: '', username: '', businessName: '', country: '' });
   const [loading, setLoading] = useState(false);


### PR DESCRIPTION
closes #243
closes #244 
closes #245 
closes #246
Problem
src/app/waitlist/page.tsx has no route-level metadata export, so a marketing link to /waitlist shared externally inherits the generic root title/description rather than waitlist-specific copy.

Impact
The waitlist page is explicitly a public marketing/growth surface (per its own copy, "Be first to access DupDub when we launch") — generic shared-link previews undersell this specific call-to-action compared to a tailored title/description/OG image.


None of the routes under src/app/dashboard/ (or src/app/dashboard/layout.tsx itself) set robots: { index: false } in a metadata export — the only protection against these pages being crawled/indexed is the client-side auth redirect in DashboardLayout.

Impact
Given the reported hydration race where the dashboard layout can briefly render null or (in a worse case) partial content before the auth check resolves, there's no explicit signal telling crawlers to stay away from private merchant financial data under /dashboard/*.
