### PR TITLE
enhance: settings validation feedback, payment expiry/copy, settlemen…

### DIFF
--- a/src/app/dashboard/settings/page.tsx
+++ b/src/app/dashboard/settings/page.tsx
@@ -13,6 +13,7 @@ export default function SettingsPage() {
   const [saving, setSaving] = useState(false);
   const [apiKey, setApiKey] = useState<string | null>(null);
   const [generatingKey, setGeneratingKey] = useState(false);
+  const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
 
   useEffect(() => {
     merchantApi.profile().then(({ data }) => {
@@ -30,11 +31,24 @@ export default function SettingsPage() {
   const save = async (e: React.FormEvent) => {
     e.preventDefault();
     setSaving(true);
+    setFieldErrors({});
     try {
       await merchantApi.update(form);
       toast.success('Profile updated');
-    } catch {
-      toast.error('Failed to update profile');
+    } catch (err: any) {
+      const data = err?.response?.data;
+      const errors = data?.errors;
+      if (errors && typeof errors === 'object') {
+        const normalized: Record<string, string> = {};
+        for (const [field, msg] of Object.entries(errors)) {
+          normalized[field] = Array.isArray(msg) ? msg.join(', ') : String(msg);
+        }
+        setFieldErrors(normalized);
+        const first = Object.values(normalized)[0];
+        toast.error(first ?? data?.message ?? 'Failed to update profile');
+      } else {
+        toast.error(data?.message ?? 'Failed to update profile');
+      }
     } finally {
       setSaving(false);
     }
@@ -76,12 +90,15 @@ export default function SettingsPage() {
             <div key={key}>
               <label className="label">{label}</label>
               <input
-                className="input"
+                className={`input ${fieldErrors[key] ? 'border-red-400 focus:border-red-400' : ''}`}
                 inputMode={inputMode}
                 pattern={pattern}
                 value={form[key as keyof typeof form]}
                 onChange={(e) => setForm({ ...form, [key]: e.target.value })}
               />
+              {fieldErrors[key] && (
+                <p className="text-xs text-red-500 mt-1">{fieldErrors[key]}</p>
+              )}
             </div>
           ))}
           <button type="submit" disabled={saving} className="btn-primary">

--- a/src/app/dashboard/settlements/[settlementId]/page.tsx
+++ b/src/app/dashboard/settlements/[settlementId]/page.tsx
@@ -1,0 +1,109 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { ArrowLeft, Loader2, XCircle } from 'lucide-react';
+import { settlementsApi } from '@/lib/api';
+import { formatUsd, formatDate } from '@/lib/utils';
+
+const STATUS_COLORS: Record<string, string> = {
+  pending: 'bg-yellow-100 text-yellow-800',
+  processing: 'bg-blue-100 text-blue-800',
+  completed: 'bg-green-100 text-green-800',
+  failed: 'bg-red-100 text-red-800',
+};
+
+function Row({ label, value }: { label: string; value: React.ReactNode }) {
+  if (value === undefined || value === null || value === '') return null;
+  return (
+    <div className="flex items-start justify-between gap-4 py-3 border-b border-gray-100 last:border-0">
+      <span className="text-sm text-gray-500">{label}</span>
+      <span className="text-sm font-medium text-gray-900 text-right break-all">{value}</span>
+    </div>
+  );
+}
+
+export default function SettlementDetailPage({ params }: { params: { settlementId: string } }) {
+  const [settlement, setSettlement] = useState<any>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    settlementsApi.get(params.settlementId).then(({ data }) => setSettlement(data)).finally(() => setLoading(false));
+  }, [params.settlementId]);
+
+  if (loading) {
+    return (
+      <div className="p-8 flex items-center justify-center">
+        <Loader2 className="w-8 h-8 animate-spin text-brand-500" />
+      </div>
+    );
+  }
+
+  if (!settlement) {
+    return (
+      <div className="p-8">
+        <Link href="/dashboard/settlements" className="text-brand-600 text-sm hover:underline flex items-center gap-1 mb-6">
+          <ArrowLeft className="w-4 h-4" /> Back to settlements
+        </Link>
+        <div className="card p-8 text-center">
+          <XCircle className="w-12 h-12 text-red-400 mx-auto mb-4" />
+          <p className="text-gray-600">Settlement not found</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-8 max-w-2xl">
+      <Link href="/dashboard/settlements" className="text-brand-600 text-sm hover:underline flex items-center gap-1 mb-6">
+        <ArrowLeft className="w-4 h-4" /> Back to settlements
+      </Link>
+
+      <div className="card p-6">
+        <div className="flex items-center justify-between mb-6">
+          <div>
+            <h1 className="text-xl font-bold text-gray-900">Settlement</h1>
+            <p className="text-xs font-mono text-gray-500 mt-1 break-all">{settlement.id}</p>
+          </div>
+          <span className={`text-xs px-2 py-1 rounded-full font-medium ${STATUS_COLORS[settlement.status] ?? 'bg-gray-100 text-gray-800'}`}>
+            {settlement.status}
+          </span>
+        </div>
+
+        <div className="grid grid-cols-3 gap-4 mb-6">
+          <div className="bg-gray-50 rounded-lg p-3">
+            <p className="text-xs text-gray-500 mb-1">Gross</p>
+            <p className="font-semibold text-gray-900">{formatUsd(settlement.totalAmountUsd)}</p>
+          </div>
+          <div className="bg-gray-50 rounded-lg p-3">
+            <p className="text-xs text-gray-500 mb-1">Fee</p>
+            <p className="font-semibold text-red-600">-{formatUsd(settlement.feeAmountUsd)}</p>
+          </div>
+          <div className="bg-gray-50 rounded-lg p-3">
+            <p className="text-xs text-gray-500 mb-1">Net</p>
+            <p className="font-semibold text-green-700">{formatUsd(settlement.netAmountUsd)}</p>
+          </div>
+        </div>
+
+        {settlement.failureReason && (
+          <div className="bg-red-50 border border-red-200 rounded-lg p-3 text-sm text-red-700 mb-6">
+            {settlement.failureReason}
+          </div>
+        )}
+
+        <div>
+          <Row label="Fiat currency" value={settlement.fiatCurrency} />
+          <Row label="Fiat amount" value={settlement.fiatAmount != null ? `${settlement.fiatAmount} ${settlement.fiatCurrency ?? ''}`.trim() : undefined} />
+          <Row label="Partner reference" value={settlement.partnerReference} />
+          <Row label="Bank reference" value={settlement.bankReference} />
+          <Row label="Requires approval" value={settlement.requiresApproval != null ? (settlement.requiresApproval ? 'Yes' : 'No') : undefined} />
+          <Row label="Approved by" value={settlement.approvedBy} />
+          <Row label="Approved at" value={settlement.approvedAt ? formatDate(settlement.approvedAt) : undefined} />
+          <Row label="Completed at" value={settlement.completedAt ? formatDate(settlement.completedAt) : undefined} />
+          <Row label="Created" value={settlement.createdAt ? formatDate(settlement.createdAt) : undefined} />
+          <Row label="Updated" value={settlement.updatedAt ? formatDate(settlement.updatedAt) : undefined} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/dashboard/settlements/page.tsx
+++ b/src/app/dashboard/settlements/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import Link from 'next/link';
 import { settlementsApi } from '@/lib/api';
 import { formatUsd, formatDate } from '@/lib/utils';
 
@@ -42,7 +43,9 @@ export default function SettlementsPage() {
             settlements.map((s) => (
               <div key={s.id} className="px-6 py-4 space-y-1">
                 <div className="flex items-center justify-between">
-                  <span className="font-mono text-xs text-gray-500">{s.id.slice(0, 8)}...</span>
+                  <Link href={`/dashboard/settlements/${s.id}`} className="font-mono text-xs text-gray-500 hover:text-brand-700 hover:underline">
+                    {s.id.slice(0, 8)}...
+                  </Link>
                   <span className={`text-xs px-2 py-0.5 rounded-full font-medium ${STATUS_COLORS[s.status]}`}>
                     {s.status}
                   </span>
@@ -76,8 +79,12 @@ export default function SettlementsPage() {
                 <tr><td colSpan={6} className="px-6 py-8 text-center text-gray-400">No settlements yet</td></tr>
               ) : (
                 settlements.map((s) => (
-                  <tr key={s.id} className="hover:bg-gray-50">
-                    <td className="px-6 py-4 font-mono text-xs text-gray-500">{s.id.slice(0, 8)}...</td>
+                   <tr key={s.id} className="hover:bg-gray-50">
+                    <td className="px-6 py-4 font-mono text-xs text-gray-500">
+                      <Link href={`/dashboard/settlements/${s.id}`} className="hover:text-brand-700 hover:underline">
+                        {s.id.slice(0, 8)}...
+                      </Link>
+                    </td>
                     <td className="px-6 py-4">{formatUsd(s.totalAmountUsd)}</td>
                     <td className="px-6 py-4 text-red-600">-{formatUsd(s.feeAmountUsd)}</td>
                     <td className="px-6 py-4 font-semibold text-green-700">{formatUsd(s.netAmountUsd)}</td>

--- a/src/app/pay/[paymentId]/page.tsx
+++ b/src/app/pay/[paymentId]/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import { QRCodeSVG } from 'qrcode.react';
-import { Clock, CheckCircle, XCircle, Loader2 } from 'lucide-react';
+import { Clock, CheckCircle, XCircle, Loader2, Copy, Check, AlertTriangle } from 'lucide-react';
 import { paymentsApi } from '@/lib/api';
 import { formatUsd } from '@/lib/utils';
 
@@ -24,9 +24,27 @@ const STATUS_ICONS: Record<string, React.ReactNode> = {
   expired: <XCircle className="w-8 h-8 text-gray-400" />,
 };
 
+function computeExpiresAt(payment: any): Date | null {
+  if (payment?.expiresAt) return new Date(payment.expiresAt);
+  if (payment?.expiryMinutes && payment?.createdAt) {
+    return new Date(new Date(payment.createdAt).getTime() + payment.expiryMinutes * 60_000);
+  }
+  return null;
+}
+
+function formatRemaining(ms: number): string {
+  if (ms <= 0) return 'Expired';
+  const total = Math.floor(ms / 1000);
+  const minutes = Math.floor(total / 60);
+  const seconds = total % 60;
+  return `${minutes}:${seconds.toString().padStart(2, '0')}`;
+}
+
 export default function PayPage({ params }: { params: { paymentId: string } }) {
   const [payment, setPayment] = useState<any>(null);
   const [loading, setLoading] = useState(true);
+  const [now, setNow] = useState(Date.now());
+  const [copied, setCopied] = useState<string | null>(null);
 
   useEffect(() => {
     paymentsApi.getByReference(params.paymentId).then(({ data }) => setPayment(data)).finally(() => setLoading(false));
@@ -40,6 +58,27 @@ export default function PayPage({ params }: { params: { paymentId: string } }) {
 
     return () => clearInterval(interval);
   }, [params.paymentId]);
+
+  const expiresAt = payment ? computeExpiresAt(payment) : null;
+  const isPending = payment?.status === 'pending';
+  const remainingMs = expiresAt ? expiresAt.getTime() - now : 0;
+  const isExpiredByClock = isPending && expiresAt ? remainingMs <= 0 : false;
+
+  useEffect(() => {
+    if (!isPending || !expiresAt) return;
+    const tick = setInterval(() => setNow(Date.now()), 1000);
+    return () => clearInterval(tick);
+  }, [isPending, expiresAt]);
+
+  const copy = async (text: string, key: string) => {
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopied(key);
+      setTimeout(() => setCopied((c) => (c === key ? null : c)), 2000);
+    } catch {
+      /* clipboard unavailable */
+    }
+  };
 
   if (loading) {
     return (
@@ -72,8 +111,17 @@ export default function PayPage({ params }: { params: { paymentId: string } }) {
         </div>
 
         <div className="p-4 xs:p-6">
-          {payment.status === 'pending' ? (
+          {isPending ? (
             <>
+              {expiresAt && (
+                <div className={`flex items-center justify-center gap-2 rounded-lg p-3 mb-4 text-sm font-semibold ${
+                  isExpiredByClock ? 'bg-red-50 text-red-700 border border-red-200' : remainingMs < 60_000 ? 'bg-red-50 text-red-700 border border-red-200' : 'bg-gray-100 text-gray-700 border border-gray-200'
+                }`}>
+                  {isExpiredByClock ? <AlertTriangle className="w-4 h-4" /> : <Clock className="w-4 h-4" />}
+                  {isExpiredByClock ? 'This payment request has expired' : <>Expires in {formatRemaining(remainingMs)}</>}
+                </div>
+              )}
+
               <div className="flex justify-center mb-4">
                 <div className="bg-white p-3 rounded-xl border border-gray-200">
                   <QRCodeSVG value={stellarUri} size={160} />
@@ -90,9 +138,33 @@ export default function PayPage({ params }: { params: { paymentId: string } }) {
                   Your wallet signs both steps. No private keys are shared with DupDub.
                 </p>
               </div>
+
+              <div className="bg-gray-50 border border-gray-200 rounded-lg p-3 text-xs mb-3">
+                <p className="text-xs text-gray-500 mb-1">Deposit address (exact)</p>
+                <div className="flex items-center gap-2">
+                  <code className="text-sm font-mono font-bold break-all flex-1 text-gray-900">{payment.stellarDepositAddress}</code>
+                  <button
+                    onClick={() => copy(payment.stellarDepositAddress, 'address')}
+                    aria-label="Copy deposit address"
+                    className="shrink-0"
+                  >
+                    {copied === 'address' ? <Check className="w-4 h-4 text-green-500" /> : <Copy className="w-4 h-4 text-gray-400" />}
+                  </button>
+                </div>
+              </div>
+
               <div className="bg-amber-50 border border-amber-200 rounded-lg p-3 text-xs">
                 <p className="font-semibold text-amber-800 mb-1">Important: Include memo</p>
-                <code className="text-amber-900 font-bold text-sm">{payment.stellarMemo}</code>
+                <div className="flex items-center gap-2">
+                  <code className="text-amber-900 font-bold text-sm break-all flex-1">{payment.stellarMemo}</code>
+                  <button
+                    onClick={() => copy(payment.stellarMemo, 'memo')}
+                    aria-label="Copy memo"
+                    className="shrink-0"
+                  >
+                    {copied === 'memo' ? <Check className="w-4 h-4 text-green-500" /> : <Copy className="w-4 h-4 text-amber-600" />}
+                  </button>
+                </div>
                 <p className="text-amber-700 mt-1">Payment will not be detected without the memo.</p>
               </div>
             </>

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -43,6 +43,7 @@ export const paymentsApi = {
 
 export const settlementsApi = {
   list: (page = 1, limit = 20) => api.get(`/settlements?page=${page}&limit=${limit}`),
+  get: (id: string) => api.get(`/settlements/${id}`),
 };
 
 export const merchantApi = {


### PR DESCRIPTION
## Summary

Implements four enhancement issues that improve merchant and customer feedback:

- **#222 — Settings validation feedback:** The save() handler no longer discards server validation. It now reads err.response.data.errors (field-keyed) and data.message, rendering field-specific errors inline under each input and showing the first/most relevant message in the toast instead of the static "Failed to update profile".
- **#220 — Payment expiry indicator:** The customer-facing /pay/[paymentId] page now shows a live countdown ("Expires in m:ss") derived from expiresAt or expiryMinutes + createdAt. It turns red with a warning when under 1 minute or past due.
- **#221 — Copy to clipboard:** Added copy buttons for both the deposit address and the memo on the customer payment page, getting them exactly right matters most.
- **#219 — Settlement detail view:** New route /dashboard/settlements/[settlementId] shows full settlement details (amounts, references, approval/completion timestamps, failure reason). List IDs are now clickable links in both mobile and desktop layouts. Added settlementsApi.get(id) to support it.

## Changes

| File | Change |
|---|---|
| src/app/dashboard/settings/page.tsx | Field-level error state + inline rendering in save() |
| src/app/pay/[paymentId]/page.tsx | Countdown timer + copy buttons for address/memo |
| src/app/dashboard/settlements/page.tsx | Clickable settlement IDs (mobile & desktop) |
| src/app/dashboard/settlements/[settlementId]/page.tsx | New detail page |
| src/lib/api.ts | Added settlementsApi.get(id) |

## Test plan

- Settings: submit an invalid bank code/account and confirm the field shows an inline error and the toast reflects the backend message.
- Pay page: open a pending payment and confirm the countdown ticks down and turns red near expiry.
- Pay page: click copy on the deposit address and memo; confirm the icon flips to a check.
- Settlements: click a settlement ID from the list and confirm the detail page loads.

## Notes

- node_modules/ was intentionally not committed (no .gitignore present in repo; deps aren't installed locally).
- Could not run npm run type-check/lint locally since dependencies aren't installed — please verify in CI before merging.

## Related issues

Closes #222
Closes #220
Closes #221
Closes #219