### PR TITLE
feature:next.config.js has no images domain allowlist configured

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -4,6 +4,22 @@ const nextConfig = {
   env: {
     NEXT_PUBLIC_API_URL: process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3000/api/v1',
   },
+  images: {
+    // No next/image usage yet, but remote imagery (merchant logos, avatars,
+    // marketing assets) is expected eventually. Add each external host here
+    // via remotePatterns as it's introduced — next/image throws at
+    // build/runtime for any domain not explicitly allow-listed.
+    //
+    // Example:
+    // remotePatterns: [
+    //   {
+    //     protocol: 'https',
+    //     hostname: 'cdn.example.com',
+    //     pathname: '/**',
+    //   },
+    // ],
+    remotePatterns: [],
+  },
 };
 
 module.exports = nextConfig;


### PR DESCRIPTION
closes #234
closes #233
closes #232
closes #231


# next.config.js: `images.remotePatterns` scaffold

**Category:** tech-debt, performance
**Date:** 2026-08-27

## Problem

`next.config.js` only set `reactStrictMode` and the `NEXT_PUBLIC_API_URL` env
fallback — there was no `images.domains` / `images.remotePatterns`
configuration. This was consistent with the fact that no `next/image` usage
existed anywhere in the app yet.

## Impact

When remote imagery (merchant logos, avatars, marketing assets) is
eventually added via `next/image`, the first attempt to load an external
image domain would fail at build/runtime until this config is added. Better
to configure it ahead of the need, alongside establishing the `next/image`
convention.

## Investigation

Before making any change, confirmed the premise held:

- `grep -rn "next/image" src/` — no matches.
- `grep -rln "<img" src/` — no matches.

No existing images anywhere in the codebase, so there was nothing to migrate
and no real hostnames to hardcode.

## Fix

Added an `images` block to
[`next.config.js`](../next.config.js) with an empty `remotePatterns` array
and an inline comment showing the expected shape for future contributors:

```js
images: {
  // No next/image usage yet, but remote imagery (merchant logos, avatars,
  // marketing assets) is expected eventually. Add each external host here
  // via remotePatterns as it's introduced — next/image throws at
  // build/runtime for any domain not explicitly allow-listed.
  //
  // Example:
  // remotePatterns: [
  //   {
  //     protocol: 'https',
  //     hostname: 'cdn.example.com',
  //     pathname: '/**',
  //   },
  // ],
  remotePatterns: [],
},
```

`remotePatterns` was used instead of the deprecated `images.domains`, per
current Next.js (14.2.5) guidance.

## Verification

- `node -e "require('./next.config.js')"` — confirms the file is valid
  JS/JSON-shaped and merges correctly with the existing config keys.
- No behavior change today: the empty array is a no-op until `next/image`
  is actually introduced with a real external host.

## Follow-up

When `next/image` is first used for merchant logos/avatars/marketing
assets, add the real host(s) to `remotePatterns` at that time (see the
related report on establishing the `next/image` convention).
