### PR TITLE
fix: unify auth token storage, add dashboard/settlements tests, CSP headers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,8 @@ jobs:
 
       - run: npm ci
 
+      - run: npm run test
+
       - run: npm run lint
 
       - run: npm run build

--- a/README.md
+++ b/README.md
@@ -41,10 +41,18 @@ The customer-facing payment flow here is built around Stellar, not a generic mul
 ### State & data flow
 
 - **`src/lib/api.ts`** — a single Axios instance (`NEXT_PUBLIC_API_URL`, default `http://localhost:3000/api/v1`) with:
-  - a request interceptor that attaches `Authorization: Bearer <token>` from `localStorage`
-  - a response interceptor that clears the token and redirects to `/auth/login` on `401`
+  - a request interceptor that attaches `Authorization: Bearer <token>` from the Zustand auth store (single source of truth)
+  - a response interceptor that calls `logout()` on the auth store and redirects to `/auth/login` on `401`
   - grouped API helpers (`authApi`, `paymentsApi`, …) rather than ad-hoc fetches scattered through components
 - **`src/lib/store.ts`** — Zustand + `persist` for auth state (`token`, `merchant`), persisted to `localStorage` under the `dupdub-auth` key. This is the only global client state; everything else (payment lists, analytics, etc.) is fetched per-page through `api.ts`.
+
+### Auth token security
+
+The access token is persisted in `localStorage` via Zustand. Any XSS vector can read it synchronously. Mitigations in this repo:
+
+- **Single storage key** — the Axios client reads from `useAuthStore`, not a duplicate `access_token` key, so 401 logout and UI auth state stay in sync.
+- **CSP headers** — `next.config.js` sets a restrictive Content-Security-Policy (plus `X-Frame-Options`, `Referrer-Policy`) to reduce XSS blast radius.
+- **Recommended long-term fix** — move to an `httpOnly`, `SameSite=Strict` session cookie issued by `dupdap-backend`, with the frontend never handling the raw JWT.
 - **`src/lib/utils.ts`** — shared formatting/className helpers (`clsx` + `tailwind-merge`).
 
 ### Customer payment flow (`/pay/[paymentId]`)

--- a/next.config.js
+++ b/next.config.js
@@ -1,8 +1,47 @@
 /** @type {import('next').NextConfig} */
+const apiUrl = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3000/api/v1';
+
 const nextConfig = {
   reactStrictMode: true,
   env: {
-    NEXT_PUBLIC_API_URL: process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3000/api/v1',
+    NEXT_PUBLIC_API_URL: apiUrl,
+  },
+  async headers() {
+    const connectSrc = ["'self'", apiUrl.replace(/\/api\/v1$/, '')];
+
+    return [
+      {
+        source: '/:path*',
+        headers: [
+          {
+            key: 'Content-Security-Policy',
+            value: [
+              "default-src 'self'",
+              "script-src 'self' 'unsafe-inline' 'unsafe-eval'",
+              "style-src 'self' 'unsafe-inline'",
+              `connect-src ${connectSrc.join(' ')}`,
+              "img-src 'self' data: blob:",
+              "font-src 'self'",
+              "frame-ancestors 'none'",
+              "base-uri 'self'",
+              "form-action 'self'",
+            ].join('; '),
+          },
+          {
+            key: 'X-Frame-Options',
+            value: 'DENY',
+          },
+          {
+            key: 'X-Content-Type-Options',
+            value: 'nosniff',
+          },
+          {
+            key: 'Referrer-Policy',
+            value: 'strict-origin-when-cross-origin',
+          },
+        ],
+      },
+    ];
   },
   images: {
     // No next/image usage yet, but remote imagery (merchant logos, avatars,

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "type-check": "tsc --noEmit"
+    "type-check": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "next": "14.2.5",
@@ -25,14 +27,20 @@
     "date-fns": "^3.6.0"
   },
   "devDependencies": {
+    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/react": "^16.2.0",
+    "@testing-library/user-event": "^14.6.1",
     "@types/node": "^20",
     "@types/react": "^18",
     "@types/react-dom": "^18",
+    "@vitejs/plugin-react": "^4.3.4",
     "autoprefixer": "^10.0.1",
     "eslint": "^8",
     "eslint-config-next": "14.2.5",
+    "jsdom": "^26.0.0",
     "postcss": "^8",
     "tailwindcss": "^3.4.1",
-    "typescript": "^5"
+    "typescript": "^5",
+    "vitest": "^3.0.5"
   }
 }

--- a/src/app/dashboard/admin/settlements/page.test.tsx
+++ b/src/app/dashboard/admin/settlements/page.test.tsx
@@ -1,0 +1,155 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useAuthStore } from '@/lib/store';
+import AdminSettlementsPage from './page';
+
+const mockListSettlements = vi.fn();
+const mockRetrySettlement = vi.fn();
+const mockApproveSettlement = vi.fn();
+
+vi.mock('@/lib/api', () => ({
+  adminApi: {
+    listSettlements: (...args: unknown[]) => mockListSettlements(...args),
+    retrySettlement: (...args: unknown[]) => mockRetrySettlement(...args),
+    approveSettlement: (...args: unknown[]) => mockApproveSettlement(...args),
+  },
+}));
+
+vi.mock('@/lib/store', () => ({
+  useAuthStore: vi.fn(() => ({ token: 'admin-token' })),
+}));
+
+const failedSettlement = {
+  id: 'settlement-failed-1',
+  merchantId: 'merchant-abc12345',
+  merchant: { businessName: 'Acme Corp' },
+  totalAmountUsd: 100,
+  feeAmountUsd: 2,
+  netAmountUsd: 98,
+  fiatCurrency: 'USD',
+  fiatAmount: 98,
+  status: 'failed' as const,
+  partnerReference: '',
+  bankReference: '',
+  failureReason: 'Bank timeout',
+  requiresApproval: false,
+  approvedBy: '',
+  approvedAt: '',
+  completedAt: '',
+  createdAt: '2024-01-15T10:00:00Z',
+  updatedAt: '2024-01-15T10:00:00Z',
+};
+
+const pendingApprovalSettlement = {
+  ...failedSettlement,
+  id: 'settlement-pending-1',
+  status: 'pending_approval' as const,
+  failureReason: '',
+  requiresApproval: true,
+};
+
+function mockListResponse(settlements = [failedSettlement, pendingApprovalSettlement]) {
+  return {
+    data: {
+      data: settlements,
+      total: settlements.length,
+      page: 1,
+      limit: 20,
+      totalPages: 1,
+    },
+  };
+}
+
+describe('AdminSettlementsPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockListSettlements.mockResolvedValue(mockListResponse());
+    mockRetrySettlement.mockResolvedValue({ data: {} });
+    mockApproveSettlement.mockResolvedValue({ data: {} });
+    vi.stubGlobal('confirm', vi.fn(() => true));
+  });
+
+  it('fetches settlements via adminApi without duplicating /api/v1 in the path', async () => {
+    render(<AdminSettlementsPage />);
+
+    await waitFor(() => {
+      expect(mockListSettlements).toHaveBeenCalledWith('page=1&limit=20');
+    });
+    expect(mockListSettlements.mock.calls[0][0]).not.toMatch(/api\/v1/);
+  });
+
+  it('refetches when a filter changes', async () => {
+    const user = userEvent.setup();
+    render(<AdminSettlementsPage />);
+
+    await waitFor(() => expect(mockListSettlements).toHaveBeenCalledTimes(1));
+
+    await user.selectOptions(screen.getAllByRole('combobox')[0], 'failed');
+
+    await waitFor(() => {
+      expect(mockListSettlements).toHaveBeenCalledWith('page=1&limit=20&status=failed');
+    });
+    expect(mockListSettlements.mock.calls.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('calls retrySettlement with the correct id and shows loading state', async () => {
+    let resolveRetry!: () => void;
+    mockRetrySettlement.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveRetry = resolve;
+        }),
+    );
+
+    const user = userEvent.setup();
+    render(<AdminSettlementsPage />);
+
+    await waitFor(() => expect(screen.getAllByRole('button', { name: 'Retry' }).length).toBeGreaterThan(0));
+
+    const retryButtons = screen.getAllByRole('button', { name: 'Retry' });
+    await user.click(retryButtons[0]);
+
+    expect(mockRetrySettlement).toHaveBeenCalledWith('settlement-failed-1');
+    expect(screen.getAllByRole('button', { name: 'Retrying...' })[0]).toBeDisabled();
+
+    resolveRetry();
+    await waitFor(() => expect(screen.getAllByRole('button', { name: 'Retry' })[0]).not.toBeDisabled());
+  });
+
+  it('calls approveSettlement with the correct id and shows loading state', async () => {
+    let resolveApprove!: () => void;
+    mockApproveSettlement.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveApprove = resolve;
+        }),
+    );
+
+    const user = userEvent.setup();
+    render(<AdminSettlementsPage />);
+
+    await waitFor(() =>
+      expect(screen.getAllByRole('button', { name: 'Approve' }).length).toBeGreaterThan(0),
+    );
+
+    const approveButtons = screen.getAllByRole('button', { name: 'Approve' });
+    await user.click(approveButtons[0]);
+
+    expect(mockApproveSettlement).toHaveBeenCalledWith('settlement-pending-1');
+    expect(screen.getAllByRole('button', { name: 'Approving...' })[0]).toBeDisabled();
+
+    resolveApprove();
+    await waitFor(() => expect(screen.getAllByRole('button', { name: 'Approve' })[0]).not.toBeDisabled());
+  });
+
+  it('does not fetch when there is no auth token', async () => {
+    vi.mocked(useAuthStore).mockReturnValue({ token: null });
+
+    render(<AdminSettlementsPage />);
+
+    await waitFor(() => expect(mockListSettlements).not.toHaveBeenCalled());
+
+    vi.mocked(useAuthStore).mockReturnValue({ token: 'admin-token' });
+  });
+});

--- a/src/app/dashboard/admin/settlements/page.tsx
+++ b/src/app/dashboard/admin/settlements/page.tsx
@@ -10,8 +10,9 @@ import {
   ExternalLink 
 } from 'lucide-react';
 import { useAuthStore } from '@/lib/store';
-import api from '@/lib/api';
-import { STATUS_COLORS } from '@/lib/utils';
+import { adminApi } from '@/lib/api';
+import { formatUsd, formatDate, STATUS_COLORS } from '@/lib/utils';
+import { SkeletonList, SkeletonTableRows } from '@/components/Skeleton';
 
 interface Settlement {
   id: string;

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -2,15 +2,12 @@
 
 import { useEffect, useState } from 'react';
 import { TrendingUp, CreditCard, Banknote, Clock } from 'lucide-react';
-import { paymentsApi, settlementsApi } from '@/lib/api';
+import { paymentsApi } from '@/lib/api';
 import { formatUsd, formatDate, PAYMENT_STATUS_COLORS } from '@/lib/utils';
+import { aggregatePaymentStats } from '@/lib/dashboard-stats';
 import { useAuthStore } from '@/lib/store';
+import { Skeleton, SkeletonList } from '@/components/Skeleton';
 import type { Payment, PaymentStats } from '@/lib/types';
-
-const toSafeInt = (value: unknown) => {
-  const parsed = parseInt(String(value ?? 0), 10);
-  return Number.isNaN(parsed) ? 0 : parsed;
-};
 
 export default function DashboardPage() {
   const { merchant } = useAuthStore();
@@ -30,17 +27,7 @@ export default function DashboardPage() {
       .finally(() => setLoading(false));
   }, []);
 
-  const statMap = stats.reduce(
-    (acc: Record<string, { count: number; total: number }>, s) => {
-      acc[s.status] = { count: parseInt(s.count), total: parseFloat(s.totalUsd ?? 0) };
-      return acc;
-    },
-    {},
-  );
-
-  const totalVolume = stats.reduce((acc, s) => acc + parseFloat(s.totalUsd ?? 0), 0);
-  const settledCount = statMap.settled?.count ?? 0;
-  const pendingCount = statMap.pending?.count ?? 0;
+  const { totalVolume, settledCount, pendingCount, totalPayments } = aggregatePaymentStats(stats);
 
   return (
     <div className="p-8">

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import { useAuthStore } from './store';
 import type {
   AuthResponse,
   Merchant,
@@ -15,10 +16,8 @@ const api = axios.create({
 });
 
 api.interceptors.request.use((config) => {
-  if (typeof window !== 'undefined') {
-    const token = localStorage.getItem('access_token');
-    if (token) config.headers.Authorization = `Bearer ${token}`;
-  }
+  const token = useAuthStore.getState().token;
+  if (token) config.headers.Authorization = `Bearer ${token}`;
   return config;
 });
 
@@ -26,7 +25,7 @@ api.interceptors.response.use(
   (res) => res,
   (err) => {
     if (err.response?.status === 401 && typeof window !== 'undefined') {
-      localStorage.removeItem('access_token');
+      useAuthStore.getState().logout();
       window.location.href = '/auth/login';
     }
     return Promise.reject(err);

--- a/src/lib/auth.test.ts
+++ b/src/lib/auth.test.ts
@@ -1,0 +1,104 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import axios from 'axios';
+import { useAuthStore } from './store';
+
+vi.mock('axios', () => {
+  const mockInstance = {
+    interceptors: {
+      request: { use: vi.fn() },
+      response: { use: vi.fn() },
+    },
+    get: vi.fn(),
+    post: vi.fn(),
+    patch: vi.fn(),
+    delete: vi.fn(),
+  };
+
+  return {
+    default: {
+      create: vi.fn(() => mockInstance),
+    },
+  };
+});
+
+describe('auth token single source of truth', () => {
+  let requestInterceptor: ((config: { headers: Record<string, string> }) => { headers: Record<string, string> }) | undefined;
+  let responseInterceptor: ((err: { response?: { status: number } }) => Promise<never>) | undefined;
+
+  beforeAll(async () => {
+    await import('./api');
+
+    const instance = vi.mocked(axios.create).mock.results[0]?.value;
+    requestInterceptor = vi.mocked(instance.interceptors.request.use).mock.calls[0]?.[0];
+    responseInterceptor = vi.mocked(instance.interceptors.response.use).mock.calls[0]?.[1];
+  });
+
+  beforeEach(() => {
+    localStorage.clear();
+    useAuthStore.setState({ token: null, merchant: null });
+  });
+
+  it('does not write a separate access_token localStorage key on setAuth', () => {
+    useAuthStore.getState().setAuth('test-token', {
+      id: '1',
+      email: 'a@b.com',
+      businessName: 'Acme',
+      status: 'active',
+    });
+
+    expect(localStorage.getItem('access_token')).toBeNull();
+    expect(useAuthStore.getState().token).toBe('test-token');
+    expect(JSON.parse(localStorage.getItem('dupdub-auth') ?? '{}').state.token).toBe('test-token');
+  });
+
+  it('clears legacy access_token key on logout', () => {
+    localStorage.setItem('access_token', 'stale-token');
+    useAuthStore.setState({
+      token: 'live-token',
+      merchant: { id: '1', email: 'a@b.com', businessName: 'Acme', status: 'active' },
+    });
+
+    useAuthStore.getState().logout();
+
+    expect(localStorage.getItem('access_token')).toBeNull();
+    expect(useAuthStore.getState().token).toBeNull();
+  });
+
+  it('reads the bearer token from the auth store in the request interceptor', () => {
+    useAuthStore.setState({ token: 'store-token', merchant: null });
+
+    const config = { headers: {} as Record<string, string> };
+    const result = requestInterceptor?.(config);
+
+    expect(result?.headers.Authorization).toBe('Bearer store-token');
+  });
+
+  it('omits Authorization when the auth store has no token', () => {
+    useAuthStore.setState({ token: null, merchant: null });
+
+    const config = { headers: {} as Record<string, string> };
+    const result = requestInterceptor?.(config);
+
+    expect(result?.headers.Authorization).toBeUndefined();
+  });
+
+  it('calls store logout on 401 responses instead of touching a legacy key', async () => {
+    useAuthStore.setState({
+      token: 'expired-token',
+      merchant: { id: '1', email: 'a@b.com', businessName: 'Acme', status: 'active' },
+    });
+    localStorage.setItem('access_token', 'legacy-should-not-matter');
+
+    Object.defineProperty(window, 'location', {
+      value: { href: '' },
+      writable: true,
+    });
+
+    await expect(responseInterceptor?.({ response: { status: 401 } })).rejects.toEqual({
+      response: { status: 401 },
+    });
+
+    expect(useAuthStore.getState().token).toBeNull();
+    expect(localStorage.getItem('access_token')).toBeNull();
+  });
+});

--- a/src/lib/dashboard-stats.test.ts
+++ b/src/lib/dashboard-stats.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import { aggregatePaymentStats } from './dashboard-stats';
+import type { PaymentStats } from './types';
+
+describe('aggregatePaymentStats', () => {
+  it('returns zeros for an empty stats array', () => {
+    const result = aggregatePaymentStats([]);
+
+    expect(result).toEqual({
+      statMap: {},
+      totalVolume: 0,
+      settledCount: 0,
+      pendingCount: 0,
+      totalPayments: 0,
+    });
+  });
+
+  it('aggregates a single status entry', () => {
+    const stats: PaymentStats[] = [{ status: 'settled', count: '12', totalUsd: '4500.50' }];
+    const result = aggregatePaymentStats(stats);
+
+    expect(result.statMap.settled).toEqual({ count: 12, total: 4500.5 });
+    expect(result.totalVolume).toBe(4500.5);
+    expect(result.settledCount).toBe(12);
+    expect(result.pendingCount).toBe(0);
+    expect(result.totalPayments).toBe(12);
+  });
+
+  it('aggregates multiple statuses and sums total volume and payment count', () => {
+    const stats: PaymentStats[] = [
+      { status: 'settled', count: '10', totalUsd: '1000' },
+      { status: 'pending', count: '5', totalUsd: '250.25' },
+      { status: 'failed', count: '2', totalUsd: '50' },
+    ];
+    const result = aggregatePaymentStats(stats);
+
+    expect(result.statMap.settled).toEqual({ count: 10, total: 1000 });
+    expect(result.statMap.pending).toEqual({ count: 5, total: 250.25 });
+    expect(result.statMap.failed).toEqual({ count: 2, total: 50 });
+    expect(result.totalVolume).toBe(1300.25);
+    expect(result.settledCount).toBe(10);
+    expect(result.pendingCount).toBe(5);
+    expect(result.totalPayments).toBe(17);
+  });
+
+  it('treats malformed count and totalUsd as zero', () => {
+    const stats: PaymentStats[] = [
+      { status: 'settled', count: 'not-a-number', totalUsd: 'bad' },
+      { status: 'pending', count: '', totalUsd: undefined },
+    ];
+    const result = aggregatePaymentStats(stats);
+
+    expect(result.statMap.settled).toEqual({ count: 0, total: 0 });
+    expect(result.statMap.pending).toEqual({ count: 0, total: 0 });
+    expect(result.totalVolume).toBe(0);
+    expect(result.totalPayments).toBe(0);
+  });
+});

--- a/src/lib/dashboard-stats.ts
+++ b/src/lib/dashboard-stats.ts
@@ -1,0 +1,42 @@
+import type { PaymentStats } from './types';
+
+export interface StatEntry {
+  count: number;
+  total: number;
+}
+
+export interface DashboardStatsSummary {
+  statMap: Record<string, StatEntry>;
+  totalVolume: number;
+  settledCount: number;
+  pendingCount: number;
+  totalPayments: number;
+}
+
+function safeInt(value: unknown): number {
+  const parsed = parseInt(String(value ?? 0), 10);
+  return Number.isNaN(parsed) ? 0 : parsed;
+}
+
+function safeFloat(value: unknown): number {
+  const parsed = parseFloat(String(value ?? 0));
+  return Number.isNaN(parsed) ? 0 : parsed;
+}
+
+export function aggregatePaymentStats(stats: PaymentStats[]): DashboardStatsSummary {
+  const statMap = stats.reduce<Record<string, StatEntry>>((acc, s) => {
+    acc[s.status] = { count: safeInt(s.count), total: safeFloat(s.totalUsd) };
+    return acc;
+  }, {});
+
+  const totalVolume = stats.reduce((acc, s) => acc + safeFloat(s.totalUsd), 0);
+  const totalPayments = stats.reduce((acc, s) => acc + safeInt(s.count), 0);
+
+  return {
+    statMap,
+    totalVolume,
+    settledCount: statMap.settled?.count ?? 0,
+    pendingCount: statMap.pending?.count ?? 0,
+    totalPayments,
+  };
+}

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -15,20 +15,34 @@ interface AuthState {
   logout: () => void;
 }
 
+const LEGACY_TOKEN_KEY = 'access_token';
+
+/** Remove the legacy duplicate key written before #143 unified auth storage. */
+export function clearLegacyAccessTokenKey() {
+  if (typeof window !== 'undefined') {
+    localStorage.removeItem(LEGACY_TOKEN_KEY);
+  }
+}
+
+/**
+ * Auth token is persisted via Zustand (`dupdub-auth` key) as the single source of truth.
+ * SECURITY (#142): tokens in localStorage remain readable to any XSS payload. The
+ * recommended long-term fix is an httpOnly, SameSite=Strict cookie issued by the backend.
+ */
 export const useAuthStore = create<AuthState>()(
   persist(
     (set) => ({
       token: null,
       merchant: null,
       setAuth: (token, merchant) => {
-        localStorage.setItem('access_token', token);
+        clearLegacyAccessTokenKey();
         set({ token, merchant });
       },
       logout: () => {
-        localStorage.removeItem('access_token');
+        clearLegacyAccessTokenKey();
         set({ token: null, merchant: null });
       },
     }),
-    { name: 'dupdub-auth' },
+    { name: 'dupdub-auth', onRehydrateStorage: () => () => clearLegacyAccessTokenKey() },
   ),
 );

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from 'vitest/config';
+import react from '@vitejs/plugin-react';
+import path from 'path';
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: 'jsdom',
+    setupFiles: ['./vitest.setup.ts'],
+    include: ['src/**/*.{test,spec}.{ts,tsx}'],
+  },
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+    },
+  },
+});

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom/vitest';


### PR DESCRIPTION



## PR description

### Summary

This PR addresses four related issues around auth consistency, XSS mitigation, and missing test coverage for financial dashboard pages.

Closes #139
closes #141
closes #142
closes #143

---

### #143 — Auth token exists in two localStorage keys that can drift apart

**Problem:** The Zustand persist layer wrote auth state to `dupdub-auth`, while `setAuth`/`logout` and the Axios 401 interceptor independently wrote/cleared a separate `access_token` key. After a 401, Axios thought the user was logged out but the Zustand store (and `DashboardLayout`) still showed them as authenticated.

**Changes:**
- Removed all reads/writes of the standalone `access_token` key from `store.ts` and `api.ts`
- Axios request interceptor now reads `useAuthStore.getState().token`
- Axios 401 handler now calls `useAuthStore.getState().logout()` instead of `localStorage.removeItem('access_token')`
- Added `clearLegacyAccessTokenKey()` to purge the old key on login, logout, and store rehydration
- Added `src/lib/auth.test.ts` covering store behavior and interceptor wiring

---

### #142 — JWT access token stored in plain localStorage, exposed to XSS

**Problem:** The access token was readable synchronously by any script on the page via `localStorage`.

**Changes (frontend mitigation — full fix requires backend):**
- Documented the risk and recommended long-term fix (`httpOnly`, `SameSite=Strict` cookie) in `store.ts` and `README.md`
- Added security headers in `next.config.js`: Content-Security-Policy, `X-Frame-Options`, `X-Content-Type-Options`, `Referrer-Policy`
- Eliminated duplicate token storage (#143), reducing inconsistency surface area

**Not in scope:** Moving to httpOnly cookies — requires backend changes to issue/set session cookies and stop returning raw JWTs to the client.

---

### #139 — Add tests for DashboardPage stats aggregation

**Problem:** `statMap`, `totalVolume`, `settledCount`, and `pendingCount` were inline `.reduce()`/`parseInt`/`parseFloat` calls with no tests. `totalPayments` was also referenced but never defined.

**Changes:**
- Extracted pure, typed `aggregatePaymentStats()` into `src/lib/dashboard-stats.ts`
- Updated `src/app/dashboard/page.tsx` to use it (fixes missing `totalPayments` and adds missing `Skeleton` imports)
- Added `src/lib/dashboard-stats.test.ts` covering:
  - Empty stats array
  - Single-status aggregation
  - Multi-status aggregation (volume + count sums)
  - Malformed `count`/`totalUsd` fields defaulting to zero

---

### #141 — Add tests for AdminSettlementsPage

**Problem:** The admin settlements page had zero test coverage despite handling approve/retry actions on real settlement state.

**Changes:**
- Fixed missing imports on the page (`adminApi`, `SkeletonList`, `SkeletonTableRows`, `formatUsd`, `formatDate`)
- Added `src/app/dashboard/admin/settlements/page.test.tsx` covering:
  - Fetches via `adminApi.listSettlements` with correct query params (no duplicated `/api/v1` in the path)
  - Filter changes trigger refetches with updated query string
  - `handleRetry` / `handleApprove` call the correct endpoints
  - Retry/Approve buttons show disabled loading states (`Retrying...` / `Approving...`)
  - No fetch when auth token is absent

---

### Test infrastructure

- Added Vitest + Testing Library (`vitest.config.ts`, `vitest.setup.ts`)
- Added `npm test` / `npm test:watch` scripts
- CI workflow now runs `npm run test` before lint/build

---

### Test plan

- [ ] `npm install && npm test` — all 3 test files pass
- [ ] Log in → confirm requests include `Authorization: Bearer …` header
- [ ] Trigger a 401 → confirm redirect to `/auth/login` and auth state cleared in UI
- [ ] Dashboard overview shows correct Total Volume / Settled / Pending / Total Payments
- [ ] Admin settlements: filter by status, retry a failed settlement, approve a pending one
- [ ] Verify CSP/security headers in browser devtools (Network → response headers)