### PR TITLE
Fix stale auth store on 401, status-color fallback, date guard, payment fetch error handling

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from 'react';
 import { TrendingUp, CreditCard, Banknote, Clock } from 'lucide-react';
 import { paymentsApi, settlementsApi } from '@/lib/api';
-import { formatUsd, formatDate, PAYMENT_STATUS_COLORS } from '@/lib/utils';
+import { formatUsd, formatDate, PAYMENT_STATUS_COLORS, DEFAULT_STATUS_COLOR } from '@/lib/utils';
 import { useAuthStore } from '@/lib/store';
 import type { Payment, PaymentStats } from '@/lib/types';
 
@@ -94,7 +94,7 @@ export default function DashboardPage() {
                   <p className="text-xs text-gray-400">{formatDate(p.createdAt)}</p>
                 </div>
                 <div className="flex items-center gap-3">
-                  <span className={`text-xs px-2 py-0.5 rounded-full font-medium ${PAYMENT_STATUS_COLORS[p.status]}`}>
+                  <span className={`text-xs px-2 py-0.5 rounded-full font-medium ${PAYMENT_STATUS_COLORS[p.status] ?? DEFAULT_STATUS_COLOR}`}>
                     {p.status}
                   </span>
                   <span className="text-sm font-semibold">{formatUsd(p.amountUsd)}</span>

--- a/src/app/dashboard/payments/page.tsx
+++ b/src/app/dashboard/payments/page.tsx
@@ -5,7 +5,7 @@ import { Plus, Copy, Check } from 'lucide-react';
 import toast from 'react-hot-toast';
 import { QRCodeSVG } from 'qrcode.react';
 import { paymentsApi } from '@/lib/api';
-import { formatUsd, formatDate, PAYMENT_STATUS_COLORS } from '@/lib/utils';
+import { formatUsd, formatDate, PAYMENT_STATUS_COLORS, DEFAULT_STATUS_COLOR } from '@/lib/utils';
 import { FormField } from '@/components/FormField';
 import { getErrorMessage } from '@/lib/errors';
 import type { Payment, PaymentListResponse } from '@/lib/types';
@@ -161,7 +161,7 @@ export default function PaymentsPage() {
               <div key={p.id} className="px-6 py-4 space-y-1">
                 <div className="flex items-center justify-between">
                   <span className="font-mono text-xs text-gray-500">{p.reference}</span>
-                  <span className={`text-xs px-2 py-0.5 rounded-full font-medium ${PAYMENT_STATUS_COLORS[p.status]}`}>
+                  <span className={`text-xs px-2 py-0.5 rounded-full font-medium ${PAYMENT_STATUS_COLORS[p.status] ?? DEFAULT_STATUS_COLOR}`}>
                     {p.status}
                   </span>
                 </div>
@@ -199,7 +199,7 @@ export default function PaymentsPage() {
                     <td className="px-6 py-4 font-mono text-xs">{p.reference}</td>
                     <td className="px-6 py-4 font-semibold">{formatUsd(p.amountUsd)}</td>
                     <td className="px-6 py-4">
-                      <span data-testid="payment-status-badge" className={`text-xs px-2 py-0.5 rounded-full font-medium ${PAYMENT_STATUS_COLORS[p.status]}`}>
+                      <span data-testid="payment-status-badge" className={`text-xs px-2 py-0.5 rounded-full font-medium ${PAYMENT_STATUS_COLORS[p.status] ?? DEFAULT_STATUS_COLOR}`}>
                         {p.status}
                       </span>
                     </td>

--- a/src/app/pay/[paymentId]/page.tsx
+++ b/src/app/pay/[paymentId]/page.tsx
@@ -54,12 +54,16 @@ function formatRemaining(ms: number): string {
 export default function PayPage({ params }: { params: { paymentId: string } }) {
   const [payment, setPayment] = useState<Payment | null>(null);
   const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState(false);
   const [now, setNow] = useState(Date.now());
   const [copied, setCopied] = useState<string | null>(null);
 
   useEffect(() => {
     let pollAttempts = 0;
-    paymentsApi.getByReference(params.paymentId).then(({ data }) => setPayment(data)).finally(() => setLoading(false));
+    paymentsApi.getByReference(params.paymentId)
+      .then(({ data }) => setPayment(data))
+      .catch(() => setLoadError(true))
+      .finally(() => setLoading(false));
 
     const interval = setInterval(() => {
       pollAttempts += 1;
@@ -116,7 +120,9 @@ export default function PayPage({ params }: { params: { paymentId: string } }) {
       <div className="min-h-screen flex items-center justify-center">
         <div className="text-center">
           <XCircle className="w-12 h-12 text-red-400 mx-auto mb-4" />
-          <p className="text-gray-600">Payment not found</p>
+          <p className="text-gray-600">
+            {loadError ? 'Something went wrong loading this payment — try again' : 'Payment not found'}
+          </p>
         </div>
       </div>
     );

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import { useAuthStore } from './store';
 import type {
   AuthResponse,
   Merchant,
@@ -26,7 +27,7 @@ api.interceptors.response.use(
   (res) => res,
   (err) => {
     if (err.response?.status === 401 && typeof window !== 'undefined') {
-      localStorage.removeItem('access_token');
+      useAuthStore.getState().logout();
       window.location.href = '/auth/login';
     }
     return Promise.reject(err);

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -17,14 +17,17 @@ export function getErrorMessage(err: unknown, fallback: string): string {
   return fallback;
 }
 
-export function formatDate(date: string | Date): string {
+export function formatDate(date: string | Date | undefined | null): string {
+  if (!date) return '—';
+  const d = new Date(date);
+  if (isNaN(d.getTime())) return '—';
   return new Intl.DateTimeFormat('en-US', {
     year: 'numeric',
     month: 'short',
     day: 'numeric',
     hour: '2-digit',
     minute: '2-digit',
-  }).format(new Date(date));
+  }).format(d);
 }
 
 export const STATUS_COLORS: Record<string, string> = {
@@ -41,6 +44,8 @@ export const STATUS_COLORS: Record<string, string> = {
 
 /** @deprecated use STATUS_COLORS */
 export const PAYMENT_STATUS_COLORS = STATUS_COLORS;
+
+export const DEFAULT_STATUS_COLOR = 'bg-gray-100 text-gray-600';
 
 export const WEBHOOK_EVENTS = [
   'payment.created',


### PR DESCRIPTION
## Summary
- `src/lib/api.ts`: the response interceptor now calls `useAuthStore.getState().logout()` on a 401 instead of only doing `localStorage.removeItem('access_token')`, so the persisted Zustand `dupdub-auth` state (token, merchant) is cleared alongside the token key.
- `src/lib/utils.ts`: `formatDate` now guards against a missing/unparseable date and returns `"—"` instead of rendering `"Invalid Date"`.
- `src/lib/utils.ts` + usage sites (`src/app/dashboard/page.tsx`, `src/app/dashboard/payments/page.tsx`): added a `DEFAULT_STATUS_COLOR` fallback so an unrecognized `PAYMENT_STATUS_COLORS[status]` lookup no longer resolves to `undefined` classes.
- `src/app/pay/[paymentId]/page.tsx`: the initial payment fetch now has a `.catch()` that sets a distinct error state, so backend failures (404/500/network) no longer all collapse into the generic "Payment not found" message.

Closes #171
Closes #172
Closes #173
Closes #174

## Warning
This PR implements the fixes only — it has **not** been tested (no dev server run, no manual verification, no test suite run). Please test before merging.