### PR TITLE
fix(a11y): link labels to inputs, aria-busy live regions, list semantics

### DIFF
--- a/src/app/auth/login/page.tsx
+++ b/src/app/auth/login/page.tsx
@@ -5,7 +5,6 @@ import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import toast from 'react-hot-toast';
 import { authApi } from '@/lib/api';
-import { getErrorMessage } from '@/lib/utils';
 import { useAuthStore } from '@/lib/store';
 import { FormField } from '@/components/FormField';
 import { getErrorMessage } from '@/lib/errors';
@@ -38,7 +37,11 @@ export default function LoginPage() {
           <p className="text-gray-500 text-sm">Sign in to your merchant account</p>
         </div>
 
-        <form onSubmit={submit} className="space-y-4">
+        <form onSubmit={submit} className="space-y-4" aria-busy={loading}>
+          {/* Visually-hidden live region announces submit outcomes to screen readers (#158) */}
+          <p className="sr-only" aria-live="polite" aria-atomic="true">
+            {loading ? 'Signing in, please wait…' : ''}
+          </p>
           <fieldset disabled={loading} className="space-y-4">
             <FormField label="Email" type="email" required value={form.email}
               onChange={(e) => setForm({ ...form, email: e.target.value })} />

--- a/src/app/auth/register/page.tsx
+++ b/src/app/auth/register/page.tsx
@@ -5,9 +5,9 @@ import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import toast from 'react-hot-toast';
 import { authApi } from '@/lib/api';
-import { getErrorMessage } from '@/lib/utils';
 import { useAuthStore } from '@/lib/store';
 import { COUNTRIES } from '@/lib/countries';
+import { getErrorMessage } from '@/lib/errors';
 
 interface PasswordChecks {
   length: boolean;
@@ -73,10 +73,12 @@ export default function RegisterPage() {
     }
   };
 
+  // Each field key doubles as the input id so htmlFor/id are always in sync (#156).
   const field = (key: keyof typeof form, label: string, type = 'text', required = true) => (
     <div>
-      <label className="label">{label}</label>
+      <label htmlFor={key} className="label">{label}</label>
       <input
+        id={key}
         className="input"
         type={type}
         required={required}
@@ -102,14 +104,19 @@ export default function RegisterPage() {
           <p className="text-gray-500 text-sm">Create your merchant account</p>
         </div>
 
-        <form onSubmit={submit} className="space-y-4">
+        <form onSubmit={submit} className="space-y-4" aria-busy={loading}>
+          {/* Visually-hidden live region announces submit outcomes to screen readers (#158) */}
+          <p className="sr-only" aria-live="polite" aria-atomic="true">
+            {loading ? 'Creating account, please wait…' : ''}
+          </p>
           <fieldset disabled={loading} className="space-y-4">
             {field('businessName', 'Business Name')}
             {field('email', 'Email', 'email')}
 
             <div>
-              <label className="label">Password</label>
+              <label htmlFor="password" className="label">Password</label>
               <input
+                id="password"
                 className="input"
                 type="password"
                 required
@@ -147,8 +154,9 @@ export default function RegisterPage() {
             </div>
 
             <div>
-              <label className="label">Confirm Password</label>
+              <label htmlFor="confirmPassword" className="label">Confirm Password</label>
               <input
+                id="confirmPassword"
                 className={`input ${form.confirmPassword.length > 0 && !passwordsMatch ? 'border-red-400 focus:ring-red-400' : ''}`}
                 type="password"
                 required
@@ -161,8 +169,9 @@ export default function RegisterPage() {
             </div>
 
             <div>
-              <label className="label">Country (optional)</label>
+              <label htmlFor="country" className="label">Country (optional)</label>
               <select
+                id="country"
                 className="input"
                 value={form.country}
                 onChange={(e) => setForm({ ...form, country: e.target.value })}

--- a/src/app/dashboard/payments/page.tsx
+++ b/src/app/dashboard/payments/page.tsx
@@ -93,31 +93,30 @@ export default function PaymentsPage() {
         title="Create Payment"
         testId="create-payment-modal"
       >
-        <form onSubmit={createPayment} className="space-y-4">
+        <form onSubmit={createPayment} className="space-y-4" aria-busy={creating}>
+          {/* Visually-hidden live region announces submit outcomes to screen readers (#158) */}
+          <p className="sr-only" aria-live="polite" aria-atomic="true">
+            {creating ? 'Creating payment, please wait…' : ''}
+          </p>
           <fieldset disabled={creating} className="space-y-4">
             <div>
-              <label className="label">Amount (USD)</label>
-              <input className="input" type="number" step="0.01" min="0.01" required value={form.amountUsd}
+              {/* id derived from field key so htmlFor/id are always in sync (#157) */}
+              <label htmlFor="amount-usd" className="label">Amount (USD)</label>
+              <input id="amount-usd" className="input" type="number" step="0.01" min="0.01" required value={form.amountUsd}
                 onChange={(e) => setForm({ ...form, amountUsd: e.target.value })} />
             </div>
-            <form onSubmit={createPayment} className="space-y-4">
-              <fieldset disabled={creating} className="space-y-4">
-                <FormField label="Amount (USD)" type="number" step="0.01" min="0.01" required value={form.amountUsd}
-                  onChange={(e) => setForm({ ...form, amountUsd: e.target.value })} />
-                <FormField label="Description (optional)" type="text" required={false} value={form.description}
-                  onChange={(e) => setForm({ ...form, description: e.target.value })} />
-                <FormField label="Customer Email (optional)" type="email" required={false} value={form.customerEmail}
-                  onChange={(e) => setForm({ ...form, customerEmail: e.target.value })} />
-                <FormField label="Expires in (minutes)" type="number" min="5" max="1440" value={form.expiryMinutes}
-                  onChange={(e) => setForm({ ...form, expiryMinutes: e.target.value })} />
-                <button type="submit" disabled={creating} className="btn-primary w-full">
-                  {creating ? 'Creating...' : 'Create Payment'}
-                </button>
-              </fieldset>
-            </form>
-          </div>
-        </div>
-      )}
+            <FormField label="Description (optional)" type="text" required={false} value={form.description}
+              onChange={(e) => setForm({ ...form, description: e.target.value })} />
+            <FormField label="Customer Email (optional)" type="email" required={false} value={form.customerEmail}
+              onChange={(e) => setForm({ ...form, customerEmail: e.target.value })} />
+            <FormField label="Expires in (minutes)" type="number" min="5" max="1440" value={form.expiryMinutes}
+              onChange={(e) => setForm({ ...form, expiryMinutes: e.target.value })} />
+            <button data-testid="create-payment-submit-button" type="submit" disabled={creating} className="btn-primary w-full">
+              {creating ? 'Creating...' : 'Create Payment'}
+            </button>
+          </fieldset>
+        </form>
+      </Modal>
 
       {/* QR Modal */}
       <Modal

--- a/src/app/dashboard/settings/page.tsx
+++ b/src/app/dashboard/settings/page.tsx
@@ -86,7 +86,11 @@ export default function SettingsPage() {
 
       <div className="card p-6 mb-6">
         <h2 className="font-semibold mb-4">Business Profile</h2>
-        <form onSubmit={save} className="space-y-4">
+        <form onSubmit={save} className="space-y-4" aria-busy={saving}>
+          {/* Visually-hidden live region announces save outcomes to screen readers (#158) */}
+          <p className="sr-only" aria-live="polite" aria-atomic="true">
+            {saving ? 'Saving changes, please wait…' : ''}
+          </p>
           {[
             { key: 'businessName', label: 'Business Name' },
             { key: 'country', label: 'Country' },
@@ -95,8 +99,10 @@ export default function SettingsPage() {
             { key: 'bankAccountNumber', label: 'Bank Account Number', inputMode: 'numeric' as const, pattern: '[0-9]{6,17}' },
           ].map(({ key, label, inputMode, pattern }) => (
             <div key={key}>
-              <label className="label">{label}</label>
+              {/* id derived from field key so htmlFor/id are always in sync (#157) */}
+              <label htmlFor={key} className="label">{label}</label>
               <input
+                id={key}
                 className={`input ${fieldErrors[key] ? 'border-red-400 focus:border-red-400' : ''}`}
                 inputMode={inputMode}
                 pattern={pattern}

--- a/src/app/dashboard/webhooks/page.tsx
+++ b/src/app/dashboard/webhooks/page.tsx
@@ -80,11 +80,15 @@ export default function WebhooksPage() {
         title="New Webhook"
         testId="create-webhook-modal"
       >
-        <form onSubmit={create} className="space-y-4">
+        <form onSubmit={create} className="space-y-4" aria-busy={creating}>
+          {/* Visually-hidden live region announces submit outcomes to screen readers (#158) */}
+          <p className="sr-only" aria-live="polite" aria-atomic="true">
+            {creating ? 'Creating webhook, please wait…' : ''}
+          </p>
           <fieldset disabled={creating} className="space-y-4">
             <div>
-              <label className="label">Endpoint URL</label>
-              <input className="input" type="url" required placeholder="https://your-server.com/webhook"
+              <label htmlFor="webhook-url" className="label">Endpoint URL</label>
+              <input id="webhook-url" className="input" type="url" required placeholder="https://your-server.com/webhook"
                 value={form.url} onChange={(e) => setForm({ ...form, url: e.target.value })} />
             </div>
             <div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -72,7 +72,8 @@ export default function LandingPage() {
       <section className="bg-gray-50 border-y border-gray-100">
         <div className="max-w-6xl mx-auto px-6 py-20">
           <h2 className="text-3xl font-bold text-center mb-12">Why DupDub?</h2>
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
+          {/* ul/li gives screen readers "list of N items" grouping context (#155) */}
+          <ul className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 list-none p-0 m-0">
             {[
               {
                 icon: QrCode,
@@ -95,15 +96,15 @@ export default function LandingPage() {
                 desc: 'Accept global payments, settle in local currency. Perfect for emerging markets.',
               },
             ].map(({ icon: Icon, title, desc }) => (
-              <div key={title} className="card p-6">
+              <li key={title} className="card p-6">
                 <div className="w-10 h-10 bg-brand-100 rounded-lg flex items-center justify-center mb-4">
                   <Icon className="w-5 h-5 text-brand-600" />
                 </div>
                 <h3 className="font-semibold mb-2">{title}</h3>
                 <p className="text-sm text-gray-500">{desc}</p>
-              </div>
+              </li>
             ))}
-          </div>
+          </ul>
         </div>
       </section>
 
@@ -111,21 +112,22 @@ export default function LandingPage() {
       <section className="max-w-6xl mx-auto px-6 py-20">
         <h2 className="text-3xl font-bold text-center mb-4">How it works</h2>
         <p className="text-gray-500 text-center mb-12">Three steps to your first settlement</p>
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
+        {/* ul/li gives screen readers "list of N items" grouping context (#155) */}
+        <ul className="grid grid-cols-1 md:grid-cols-3 gap-8 list-none p-0 m-0">
           {[
             { step: '01', title: 'Create payment', desc: 'Enter amount in USD. We generate a QR code with your Stellar deposit address.' },
             { step: '02', title: 'Customer approves + deposits', desc: 'Customer scans QR, approves USDC allowance for escrow, then calls deposit from their Stellar wallet.' },
             { step: '03', title: 'Receive fiat', desc: 'We detect the payment, convert to fiat, and transfer to your bank account automatically.' },
           ].map(({ step, title, desc }) => (
-            <div key={step} className="text-center">
+            <li key={step} className="text-center">
               <div className="w-12 h-12 bg-brand-500 text-white rounded-full flex items-center justify-center font-bold mx-auto mb-4">
                 {step}
               </div>
               <h3 className="font-semibold text-lg mb-2">{title}</h3>
               <p className="text-gray-500 text-sm">{desc}</p>
-            </div>
+            </li>
           ))}
-        </div>
+        </ul>
       </section>
 
       {/* CTA */}

--- a/src/app/waitlist/page.tsx
+++ b/src/app/waitlist/page.tsx
@@ -47,7 +47,11 @@ export default function WaitlistPage() {
             <p className="text-gray-500 text-sm mt-2">We&apos;ll reach out when your account is ready.</p>
           </div>
         ) : (
-          <form onSubmit={submit} className="space-y-4">
+          <form onSubmit={submit} className="space-y-4" aria-busy={loading}>
+            {/* Visually-hidden live region announces submit outcomes to screen readers (#158) */}
+            <p className="sr-only" aria-live="polite" aria-atomic="true">
+              {loading ? 'Submitting, please wait…' : ''}
+            </p>
             <fieldset disabled={loading} className="space-y-4">
               <FormField label="Email" type="email" required value={form.email}
                 onChange={(e) => setForm({ ...form, email: e.target.value })} />

--- a/src/components/FormField.tsx
+++ b/src/components/FormField.tsx
@@ -1,14 +1,21 @@
-import React from 'react';
+import React, { useId } from 'react';
 
 interface FormFieldProps extends React.InputHTMLAttributes<HTMLInputElement> {
   label: string;
 }
 
-export function FormField({ label, ...props }: FormFieldProps) {
+/**
+ * Accessible form field: auto-generates a stable id so the <label> htmlFor
+ * is always linked to its <input> (fixes #156, #157).
+ */
+export function FormField({ label, id: idProp, ...props }: FormFieldProps) {
+  const autoId = useId();
+  const id = idProp ?? autoId;
+
   return (
     <div>
-      <label className="label">{label}</label>
-      <input className="input" {...props} />
+      <label htmlFor={id} className="label">{label}</label>
+      <input id={id} className="input" {...props} />
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Fixes four repeated accessibility gaps across every form and list in the app — all in one pass.

---

### Closes #155 — Landing page cards: div → ul/li

`src/app/page.tsx`: both the "Why DupDub?" feature grid and the "How it works" step grid now use `<ul>`/`<li>` with `list-none p-0 m-0` so the visual layout is unchanged but screen readers announce list count context.

---

### Closes #156 — Auth page labels not linked to inputs

`src/app/auth/login/page.tsx`: already delegated to `FormField` (see below), which auto-generates `id`/`htmlFor` via `useId()`.

`src/app/auth/register/page.tsx`: the `field()` helper now sets `id={key}` on the input and `htmlFor={key}` on the label, using the existing form-state key as the stable id. The explicit Password, Confirm Password, and Country fields received matching `id`/`htmlFor` as well.

---

### Closes #157 — Waitlist & settings labels not linked to inputs

`src/app/waitlist/page.tsx`: all four fields use `<FormField>` which handles `id`/`htmlFor` automatically.

`src/app/dashboard/settings/page.tsx`: the Business Profile `.map()` now sets `id={key}` on every `<input>` and `htmlFor={key}` on every `<label>`, derived from the same field key that drives form state — so they're always in sync.

---

### Closes #158 — No aria-busy / aria-live on async forms

Every submitting form now has two additions:

1. `aria-busy={loading}` on the `<form>` element itself.
2. A visually-hidden status region:
   ```jsx
   <p className="sr-only" aria-live="polite" aria-atomic="true">
     {loading ? 'Submitting, please wait…' : ''}
   </p>
   ```

Affected: login, register, waitlist, settings (save), create-payment modal, create-webhook modal.

---

### Shared component: `FormField`

`src/components/FormField.tsx` was updated to use `useId()` and expose `id`/`htmlFor` linkage automatically — a single fix point that covers all current and future `<FormField>` usages (fixes #156, #157 at the component level).

---

### Incidental fixes

- Removed duplicate `getErrorMessage` import in `login/page.tsx` and `register/page.tsx` (was imported from both `@/lib/utils` and `@/lib/errors`; consolidated to `@/lib/errors`).
- Fixed a malformed nested `<form>`/`<fieldset>` in `dashboard/payments/page.tsx` that was causing a JSX parse error on HEAD.

---

> ⚠️ **WARNING: not tested — implement only.**