### PR TITLE
Improve auth UX, API key handling, and landing nav a11y

### DIFF
--- a/src/app/auth/login/page.tsx
+++ b/src/app/auth/login/page.tsx
@@ -3,28 +3,56 @@
 import { useState } from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
+import { AxiosError } from 'axios';
 import toast from 'react-hot-toast';
 import { authApi } from '@/lib/api';
-import { getErrorMessage } from '@/lib/utils';
+import { getErrorMessage } from '@/lib/errors';
 import { useAuthStore } from '@/lib/store';
 import { FormField } from '@/components/FormField';
-import { getErrorMessage } from '@/lib/errors';
+
+const CAPTCHA_THRESHOLD = 3;
+
+function getRateLimitMessage(err: AxiosError): string {
+  const retryAfter = err.response?.headers['retry-after'];
+  const seconds = retryAfter ? Number(retryAfter) : NaN;
+  if (!Number.isNaN(seconds) && seconds > 0) {
+    const minutes = Math.max(1, Math.ceil(seconds / 60));
+    return `Too many login attempts. Please try again in ${minutes} minute${minutes === 1 ? '' : 's'}.`;
+  }
+  const serverMessage = (err.response?.data as { message?: string } | undefined)?.message;
+  if (serverMessage) return serverMessage;
+  return 'Too many login attempts. Please try again later.';
+}
 
 export default function LoginPage() {
   const router = useRouter();
   const setAuth = useAuthStore((s) => s.setAuth);
   const [loading, setLoading] = useState(false);
+  const [failedAttempts, setFailedAttempts] = useState(0);
+  const [rateLimited, setRateLimited] = useState(false);
+  const [rateLimitMessage, setRateLimitMessage] = useState<string | null>(null);
   const [form, setForm] = useState({ email: '', password: '' });
+
+  const showCaptcha = failedAttempts >= CAPTCHA_THRESHOLD;
 
   const submit = async (e: React.FormEvent) => {
     e.preventDefault();
+    if (rateLimited) return;
     setLoading(true);
     try {
       const { data } = await authApi.login(form);
       setAuth(data.accessToken, data.merchant);
       router.push('/dashboard');
     } catch (err) {
-      toast.error(getErrorMessage(err) ?? 'Login failed');
+      if (err instanceof AxiosError && err.response?.status === 429) {
+        const message = getRateLimitMessage(err);
+        setRateLimited(true);
+        setRateLimitMessage(message);
+        toast.error(message);
+      } else {
+        setFailedAttempts((count) => count + 1);
+        toast.error(getErrorMessage(err) ?? 'Login failed');
+      }
     } finally {
       setLoading(false);
     }
@@ -38,14 +66,46 @@ export default function LoginPage() {
           <p className="text-gray-500 text-sm">Sign in to your merchant account</p>
         </div>
 
+        {rateLimitMessage ? (
+          <div
+            role="alert"
+            className="mb-4 rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800"
+          >
+            {rateLimitMessage}
+          </div>
+        ) : null}
+
         <form onSubmit={submit} className="space-y-4">
-          <fieldset disabled={loading} className="space-y-4">
-            <FormField label="Email" type="email" required value={form.email}
-              onChange={(e) => setForm({ ...form, email: e.target.value })} />
-            <FormField label="Password" type="password" required value={form.password}
-              onChange={(e) => setForm({ ...form, password: e.target.value })} />
-            <button data-testid="login-submit-button" type="submit" disabled={loading} className="btn-primary w-full">
-              {loading ? 'Signing in...' : 'Sign in'}
+          <fieldset disabled={loading || rateLimited} className="space-y-4">
+            <FormField
+              label="Email"
+              type="email"
+              required
+              autoComplete="email"
+              value={form.email}
+              onChange={(e) => setForm({ ...form, email: e.target.value })}
+            />
+            <FormField
+              label="Password"
+              type="password"
+              required
+              autoComplete="current-password"
+              value={form.password}
+              onChange={(e) => setForm({ ...form, password: e.target.value })}
+            />
+
+            {showCaptcha ? (
+              <div
+                data-testid="login-captcha-slot"
+                className="rounded-lg border border-dashed border-gray-300 bg-gray-50 p-4 text-center text-sm text-gray-500"
+                aria-label="CAPTCHA verification"
+              >
+                Complete verification to continue signing in.
+              </div>
+            ) : null}
+
+            <button data-testid="login-submit-button" type="submit" disabled={loading || rateLimited} className="btn-primary w-full">
+              {loading ? 'Signing in...' : rateLimited ? 'Try again later' : 'Sign in'}
             </button>
           </fieldset>
         </form>

--- a/src/app/auth/register/page.tsx
+++ b/src/app/auth/register/page.tsx
@@ -73,13 +73,20 @@ export default function RegisterPage() {
     }
   };
 
-  const field = (key: keyof typeof form, label: string, type = 'text', required = true) => (
+  const field = (
+    key: keyof typeof form,
+    label: string,
+    type = 'text',
+    required = true,
+    autoComplete?: string,
+  ) => (
     <div>
       <label className="label">{label}</label>
       <input
         className="input"
         type={type}
         required={required}
+        autoComplete={autoComplete}
         value={form[key]}
         onChange={(e) => setForm({ ...form, [key]: e.target.value })}
       />
@@ -104,8 +111,8 @@ export default function RegisterPage() {
 
         <form onSubmit={submit} className="space-y-4">
           <fieldset disabled={loading} className="space-y-4">
-            {field('businessName', 'Business Name')}
-            {field('email', 'Email', 'email')}
+            {field('businessName', 'Business Name', 'text', true, 'organization')}
+            {field('email', 'Email', 'email', true, 'email')}
 
             <div>
               <label className="label">Password</label>
@@ -113,6 +120,7 @@ export default function RegisterPage() {
                 className="input"
                 type="password"
                 required
+                autoComplete="new-password"
                 value={form.password}
                 onChange={(e) => setForm({ ...form, password: e.target.value })}
               />
@@ -152,6 +160,7 @@ export default function RegisterPage() {
                 className={`input ${form.confirmPassword.length > 0 && !passwordsMatch ? 'border-red-400 focus:ring-red-400' : ''}`}
                 type="password"
                 required
+                autoComplete="new-password"
                 value={form.confirmPassword}
                 onChange={(e) => setForm({ ...form, confirmPassword: e.target.value })}
               />

--- a/src/app/dashboard/settings/page.tsx
+++ b/src/app/dashboard/settings/page.tsx
@@ -1,10 +1,16 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import { Copy, Check, Eye, EyeOff } from 'lucide-react';
 import toast from 'react-hot-toast';
 import { merchantApi } from '@/lib/api';
 import { useAuthStore } from '@/lib/store';
 import { FormField } from '@/components/FormField';
+
+function maskApiKey(key: string): string {
+  if (key.length <= 8) return '••••••••';
+  return `${key.slice(0, 4)}${'•'.repeat(Math.min(key.length - 8, 24))}${key.slice(-4)}`;
+}
 
 export default function SettingsPage() {
   const { merchant } = useAuthStore();
@@ -13,6 +19,8 @@ export default function SettingsPage() {
   const [selectedScopes, setSelectedScopes] = useState<string[]>(['payments:read', 'settlements:read']);
   const [saving, setSaving] = useState(false);
   const [apiKey, setApiKey] = useState<string | null>(null);
+  const [keyRevealed, setKeyRevealed] = useState(false);
+  const [keyCopied, setKeyCopied] = useState(false);
   const [generatingKey, setGeneratingKey] = useState(false);
   const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
 
@@ -72,12 +80,31 @@ export default function SettingsPage() {
     try {
       const { data } = await merchantApi.generateApiKey(selectedScopes);
       setApiKey(data.apiKey);
+      setKeyRevealed(false);
+      setKeyCopied(false);
       toast.success('API key generated — save it now, it won\'t be shown again');
     } catch {
       toast.error('Failed to generate API key');
     } finally {
       setGeneratingKey(false);
     }
+  };
+
+  const copyApiKey = async () => {
+    if (!apiKey) return;
+    try {
+      await navigator.clipboard.writeText(apiKey);
+      setKeyCopied(true);
+      setTimeout(() => setKeyCopied(false), 2000);
+    } catch {
+      toast.error('Failed to copy API key');
+    }
+  };
+
+  const dismissApiKey = () => {
+    setApiKey(null);
+    setKeyRevealed(false);
+    setKeyCopied(false);
   };
 
   return (
@@ -152,8 +179,38 @@ export default function SettingsPage() {
         </div>
 
         {apiKey ? (
-          <div className="bg-gray-900 text-green-400 font-mono text-sm p-3 rounded-lg break-all mb-3">
-            {apiKey}
+          <div className="mb-3 rounded-lg border border-amber-200 bg-amber-50 p-4">
+            <p className="text-sm font-medium text-amber-900 mb-2">
+              Save this key now — it won&apos;t be shown again
+            </p>
+            <div className="flex items-center gap-2 bg-gray-900 text-green-400 font-mono text-sm p-3 rounded-lg">
+              <code className="flex-1 break-all">
+                {keyRevealed ? apiKey : maskApiKey(apiKey)}
+              </code>
+              <button
+                type="button"
+                onClick={() => setKeyRevealed((current) => !current)}
+                className="shrink-0 p-1 text-gray-400 hover:text-gray-200"
+                aria-label={keyRevealed ? 'Hide API key' : 'Reveal API key'}
+              >
+                {keyRevealed ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
+              </button>
+              <button
+                type="button"
+                onClick={copyApiKey}
+                className="shrink-0 p-1 text-gray-400 hover:text-gray-200"
+                aria-label="Copy API key"
+              >
+                {keyCopied ? <Check className="w-4 h-4 text-green-500" /> : <Copy className="w-4 h-4" />}
+              </button>
+            </div>
+            <button
+              type="button"
+              onClick={dismissApiKey}
+              className="mt-3 text-sm font-medium text-brand-600 hover:underline"
+            >
+              I&apos;ve saved it, dismiss
+            </button>
           </div>
         ) : null}
         <button onClick={() => window.confirm("Are you sure you want to generate a new API key? This will invalidate your current key.") && generateKey()} disabled={generatingKey} className="btn-secondary">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
 import { ArrowRight, Zap, Shield, Globe, QrCode } from 'lucide-react';
+import { LandingNav } from '@/components/LandingNav';
 
 export const metadata: Metadata = {
   title: 'DupDub — Accept Crypto, Receive Fiat Instantly',
@@ -30,20 +31,7 @@ export default function LandingPage() {
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
       />
-      {/* Nav */}
-      <nav className="border-b border-gray-100">
-        <div className="max-w-6xl mx-auto px-6 h-16 flex items-center justify-between">
-          <span className="font-bold text-xl text-brand-600">DupDub</span>
-          <div className="flex items-center gap-4">
-            <Link href="/auth/login" className="text-sm text-gray-600 hover:text-gray-900">
-              Login
-            </Link>
-            <Link href="/auth/register" className="btn-primary text-sm">
-              Get Started
-            </Link>
-          </div>
-        </div>
-      </nav>
+      <LandingNav />
 
       {/* Hero */}
       <section className="max-w-6xl mx-auto px-6 py-24 text-center">

--- a/src/components/LandingNav.tsx
+++ b/src/components/LandingNav.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import { useState } from 'react';
+import Link from 'next/link';
+import { Menu, X } from 'lucide-react';
+
+export function LandingNav() {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <nav aria-label="Main navigation" className="border-b border-gray-100">
+      <div className="max-w-6xl mx-auto px-6 h-16 flex items-center justify-between">
+        <span className="font-bold text-xl text-brand-600">DupDub</span>
+
+        <div className="hidden sm:flex items-center gap-4">
+          <Link href="/auth/login" className="text-sm text-gray-600 hover:text-gray-900">
+            Login
+          </Link>
+          <Link href="/auth/register" className="btn-primary text-sm">
+            Get Started
+          </Link>
+        </div>
+
+        <button
+          type="button"
+          className="sm:hidden p-2 -mr-2 text-gray-600 hover:text-gray-900"
+          aria-expanded={open}
+          aria-controls="landing-mobile-menu"
+          aria-label="Toggle menu"
+          onClick={() => setOpen((current) => !current)}
+        >
+          {open ? <X className="w-5 h-5" /> : <Menu className="w-5 h-5" />}
+        </button>
+      </div>
+
+      {open ? (
+        <div
+          id="landing-mobile-menu"
+          className="sm:hidden border-t border-gray-100 px-6 py-4 space-y-3"
+        >
+          <Link
+            href="/auth/login"
+            className="block text-sm text-gray-600 hover:text-gray-900 py-2"
+            onClick={() => setOpen(false)}
+          >
+            Login
+          </Link>
+          <Link
+            href="/auth/register"
+            className="btn-primary text-sm inline-block"
+            onClick={() => setOpen(false)}
+          >
+            Get Started
+          </Link>
+        </div>
+      ) : null}
+    </nav>
+  );
+}


### PR DESCRIPTION

**PR description:**

## Summary

This PR addresses four security, accessibility, and UX issues across the auth flow, settings page, and landing page.

Closes #148
closes #149
closes #153
closes #154



### #153 — Login rate-limiting UX and CAPTCHA hook

**Problem:** Failed logins always showed a generic toast with no distinction for throttling, and there was no place to mount CAPTCHA after repeated failures.

**Changes:**
- Detect `429` responses separately from other login errors
- Show a persistent inline alert (and toast) with a user-friendly message derived from `Retry-After` when present (e.g. “try again in 5 minutes”)
- Disable the form and change the submit label while rate-limited
- Track failed attempts; after 3 failures, render a CAPTCHA slot (`data-testid="login-captcha-slot"`) ready to wire to reCAPTCHA/hCaptcha
- Fixed duplicate `getErrorMessage` import on the login page

---

### #149 — Generated API key masking, copy, and dismiss

**Problem:** A newly generated API key stayed fully visible with no copy control or way to dismiss it.

**Changes:**
- Mask the key by default (`abcd••••••••wxyz`) with a reveal/hide toggle (Eye/EyeOff)
- Add copy-to-clipboard using the same Copy/Check pattern as the payments page
- Add an explicit **“I've saved it, dismiss”** action that clears the key from view
- Wrap the key in a warning-styled panel reminding the user it won't be shown again

---

### #154 — Landing page nav accessibility and mobile menu

**Problem:** The landing `<nav>` had no `aria-label`, and links compressed on small screens with no mobile layout.

**Changes:**
- Extract nav into `LandingNav` client component with `aria-label="Main navigation"`
- Desktop links remain visible from `sm` breakpoint up
- Below `sm`: hamburger toggle with `aria-expanded`, `aria-controls`, and a collapsible mobile menu for Login / Get Started

---

### #148 — Login and register `autoComplete` attributes

**Problem:** Email and password fields lacked `autoComplete`, breaking password manager and browser autofill support.

**Changes:**
- **Login:** `autoComplete="email"` and `autoComplete="current-password"`
- **Register:** `autoComplete="email"`, `autoComplete="new-password"` on both password fields, and `autoComplete="organization"` on business name

---

## Test plan

- [ ] **Login — normal failure:** Wrong credentials show generic error; after 3 failures, CAPTCHA slot appears
- [ ] **Login — rate limit:** Mock/simulate a `429` with `Retry-After` header; confirm specific message, inline alert, and disabled submit
- [ ] **Register:** Confirm browser/password manager offers email autofill and new-password suggestions
- [ ] **Settings — API key:** Generate key → masked by default → reveal toggle works → copy button works → dismiss hides the panel
- [ ] **Landing page:** Resize to mobile width → hamburger appears → menu opens/closes → links navigate correctly
- [ ] **Landing page a11y:** Screen reader announces “Main navigation” landmark

---

## Files changed

| File | Change |
|------|--------|
| `src/app/auth/login/page.tsx` | Rate-limit handling, CAPTCHA slot, autoComplete |
| `src/app/auth/register/page.tsx` | autoComplete on form fields |
| `src/app/dashboard/settings/page.tsx` | API key mask, copy, dismiss |
| `src/app/page.tsx` | Uses new `LandingNav` |
| `src/components/LandingNav.tsx` | **New** — accessible responsive nav |