### PR TITLE
fix(a11y): explicit labels, fieldset/legend, inline errors, chart data tables

### DIFF
--- a/src/app/auth/login/page.tsx
+++ b/src/app/auth/login/page.tsx
@@ -15,16 +15,20 @@ export default function LoginPage() {
   const setAuth = useAuthStore((s) => s.setAuth);
   const [loading, setLoading] = useState(false);
   const [form, setForm] = useState({ email: '', password: '' });
+  const [formError, setFormError] = useState('');
 
   const submit = async (e: React.FormEvent) => {
     e.preventDefault();
+    setFormError('');
     setLoading(true);
     try {
       const { data } = await authApi.login(form);
       setAuth(data.accessToken, data.merchant);
       router.push('/dashboard');
     } catch (err) {
-      toast.error(getErrorMessage(err) ?? 'Login failed');
+      const msg = getErrorMessage(err) ?? 'Login failed';
+      setFormError(msg);
+      toast.error(msg);
     } finally {
       setLoading(false);
     }
@@ -39,6 +43,11 @@ export default function LoginPage() {
         </div>
 
         <form onSubmit={submit} className="space-y-4">
+          {formError && (
+            <p role="alert" className="text-sm text-red-600 bg-red-50 border border-red-200 rounded px-3 py-2">
+              {formError}
+            </p>
+          )}
           <fieldset disabled={loading} className="space-y-4">
             <FormField label="Email" type="email" required value={form.email}
               onChange={(e) => setForm({ ...form, email: e.target.value })} />

--- a/src/app/auth/register/page.tsx
+++ b/src/app/auth/register/page.tsx
@@ -38,6 +38,7 @@ export default function RegisterPage() {
   const router = useRouter();
   const setAuth = useAuthStore((s) => s.setAuth);
   const [loading, setLoading] = useState(false);
+  const [formError, setFormError] = useState('');
   const [form, setForm] = useState({
     email: '',
     password: '',
@@ -56,6 +57,7 @@ export default function RegisterPage() {
     e.preventDefault();
     if (!passwordValid) return toast.error('Please meet the password requirements');
     if (!passwordsMatch) return toast.error('Passwords do not match');
+    setFormError('');
     setLoading(true);
     try {
       const { data } = await authApi.register({
@@ -67,7 +69,9 @@ export default function RegisterPage() {
       setAuth(data.accessToken, data.merchant);
       router.push('/dashboard');
     } catch (err) {
-      toast.error(getErrorMessage(err) ?? 'Registration failed');
+      const msg = getErrorMessage(err) ?? 'Registration failed';
+      setFormError(msg);
+      toast.error(msg);
     } finally {
       setLoading(false);
     }
@@ -103,6 +107,11 @@ export default function RegisterPage() {
         </div>
 
         <form onSubmit={submit} className="space-y-4">
+          {formError && (
+            <p role="alert" className="text-sm text-red-600 bg-red-50 border border-red-200 rounded px-3 py-2">
+              {formError}
+            </p>
+          )}
           <fieldset disabled={loading} className="space-y-4">
             {field('businessName', 'Business Name')}
             {field('email', 'Email', 'email')}

--- a/src/app/dashboard/admin/settlements/page.tsx
+++ b/src/app/dashboard/admin/settlements/page.tsx
@@ -125,44 +125,60 @@ export default function AdminSettlementsPage() {
       <div className="bg-white rounded-lg border border-gray-200 p-4 mb-6">
         <div className="flex items-center gap-4 flex-wrap">
           <div className="flex items-center gap-2">
-            <Filter className="w-4 h-4 text-gray-500" />
+            <Filter className="w-4 h-4 text-gray-500" aria-hidden="true" />
             <span className="text-sm font-medium text-gray-700">Filters:</span>
           </div>
-          
-          <select
-            value={filters.status}
-            onChange={(e) => setFilters({ ...filters, status: e.target.value })}
-            className="px-3 py-1 border border-gray-300 rounded-md text-sm"
-          >
-            <option value="">All Statuses</option>
-            <option value="pending">Pending</option>
-            <option value="pending_approval">Pending Approval</option>
-            <option value="processing">Processing</option>
-            <option value="completed">Completed</option>
-            <option value="failed">Failed</option>
-          </select>
 
-          <input
-            type="text"
-            placeholder="Merchant ID"
-            value={filters.merchantId}
-            onChange={(e) => setFilters({ ...filters, merchantId: e.target.value })}
-            className="px-3 py-1 border border-gray-300 rounded-md text-sm"
-          />
+          <div className="flex flex-col gap-0.5">
+            <label htmlFor="filter-status" className="sr-only">Status</label>
+            <select
+              id="filter-status"
+              value={filters.status}
+              onChange={(e) => setFilters({ ...filters, status: e.target.value })}
+              className="px-3 py-1 border border-gray-300 rounded-md text-sm"
+            >
+              <option value="">All Statuses</option>
+              <option value="pending">Pending</option>
+              <option value="pending_approval">Pending Approval</option>
+              <option value="processing">Processing</option>
+              <option value="completed">Completed</option>
+              <option value="failed">Failed</option>
+            </select>
+          </div>
 
-          <input
-            type="date"
-            value={filters.startDate}
-            onChange={(e) => setFilters({ ...filters, startDate: e.target.value })}
-            className="px-3 py-1 border border-gray-300 rounded-md text-sm"
-          />
+          <div className="flex flex-col gap-0.5">
+            <label htmlFor="filter-merchant-id" className="sr-only">Merchant ID</label>
+            <input
+              id="filter-merchant-id"
+              type="text"
+              placeholder="Merchant ID"
+              value={filters.merchantId}
+              onChange={(e) => setFilters({ ...filters, merchantId: e.target.value })}
+              className="px-3 py-1 border border-gray-300 rounded-md text-sm"
+            />
+          </div>
 
-          <input
-            type="date"
-            value={filters.endDate}
-            onChange={(e) => setFilters({ ...filters, endDate: e.target.value })}
-            className="px-3 py-1 border border-gray-300 rounded-md text-sm"
-          />
+          <div className="flex flex-col gap-0.5">
+            <label htmlFor="filter-start-date" className="sr-only">Start Date</label>
+            <input
+              id="filter-start-date"
+              type="date"
+              value={filters.startDate}
+              onChange={(e) => setFilters({ ...filters, startDate: e.target.value })}
+              className="px-3 py-1 border border-gray-300 rounded-md text-sm"
+            />
+          </div>
+
+          <div className="flex flex-col gap-0.5">
+            <label htmlFor="filter-end-date" className="sr-only">End Date</label>
+            <input
+              id="filter-end-date"
+              type="date"
+              value={filters.endDate}
+              onChange={(e) => setFilters({ ...filters, endDate: e.target.value })}
+              className="px-3 py-1 border border-gray-300 rounded-md text-sm"
+            />
+          </div>
 
           <button
             onClick={() => setFilters({ status: '', merchantId: '', startDate: '', endDate: '' })}

--- a/src/app/dashboard/analytics/page.tsx
+++ b/src/app/dashboard/analytics/page.tsx
@@ -77,6 +77,24 @@ export default function AnalyticsPage() {
                   <Legend />
                 </PieChart>
               </ResponsiveContainer>
+              {/* Visually-hidden data table — same data as chart for screen readers */}
+              <table className="sr-only">
+                <caption>Payment Count by Status</caption>
+                <thead>
+                  <tr>
+                    <th scope="col">Status</th>
+                    <th scope="col">Count</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {pieData.map((row) => (
+                    <tr key={row.name}>
+                      <td>{row.name}</td>
+                      <td>{row.value}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
             </div>
 
             <div className="card p-6">
@@ -89,6 +107,24 @@ export default function AnalyticsPage() {
                   <Bar dataKey="amount" fill="#eab308" radius={[4, 4, 0, 0]} />
                 </BarChart>
               </ResponsiveContainer>
+              {/* Visually-hidden data table — same data as chart for screen readers */}
+              <table className="sr-only">
+                <caption>Volume by Status (USD)</caption>
+                <thead>
+                  <tr>
+                    <th scope="col">Status</th>
+                    <th scope="col">Volume (USD)</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {pieData.map((row) => (
+                    <tr key={row.name}>
+                      <td>{row.name}</td>
+                      <td>{formatUsd(row.amount)}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
             </div>
           </div>
         </div>

--- a/src/app/dashboard/webhooks/page.tsx
+++ b/src/app/dashboard/webhooks/page.tsx
@@ -14,6 +14,7 @@ export default function WebhooksPage() {
   const [creating, setCreating] = useState(false);
   const [deletingId, setDeletingId] = useState<string | null>(null);
   const [deleting, setDeleting] = useState(false);
+  const [formError, setFormError] = useState('');
 
   const load = () => webhooksApi.list().then(({ data }) => setWebhooks(data));
 
@@ -21,7 +22,12 @@ export default function WebhooksPage() {
 
   const create = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (form.events.length === 0) return toast.error('Select at least one event');
+    if (form.events.length === 0) {
+      setFormError('Select at least one event');
+      toast.error('Select at least one event');
+      return;
+    }
+    setFormError('');
     setCreating(true);
     try {
       await webhooksApi.create(form);
@@ -30,7 +36,9 @@ export default function WebhooksPage() {
       setForm({ url: '', events: [] });
       load();
     } catch (err) {
-      toast.error(getErrorMessage(err, 'Failed to create webhook'));
+      const msg = getErrorMessage(err, 'Failed to create webhook');
+      setFormError(msg);
+      toast.error(msg);
     } finally {
       setCreating(false);
     }
@@ -60,6 +68,7 @@ export default function WebhooksPage() {
   const closeCreateModal = () => {
     setShowCreate(false);
     setForm({ url: '', events: [] });
+    setFormError('');
   };
 
   return (
@@ -76,28 +85,50 @@ export default function WebhooksPage() {
 
       <Modal
         open={showCreate}
-        onClose={() => setShowCreate(false)}
+        onClose={closeCreateModal}
         title="New Webhook"
         testId="create-webhook-modal"
       >
         <form onSubmit={create} className="space-y-4">
+          {formError && (
+            <p role="alert" className="text-sm text-red-600 bg-red-50 border border-red-200 rounded px-3 py-2">
+              {formError}
+            </p>
+          )}
           <fieldset disabled={creating} className="space-y-4">
             <div>
-              <label className="label">Endpoint URL</label>
-              <input className="input" type="url" required placeholder="https://your-server.com/webhook"
-                value={form.url} onChange={(e) => setForm({ ...form, url: e.target.value })} />
+              <label htmlFor="webhook-url" className="label">Endpoint URL</label>
+              <input
+                id="webhook-url"
+                className="input"
+                type="url"
+                required
+                placeholder="https://your-server.com/webhook"
+                value={form.url}
+                onChange={(e) => setForm({ ...form, url: e.target.value })}
+              />
             </div>
-            <div>
-              <label className="label">Events</label>
+            <fieldset>
+              <legend className="label mb-1">Events</legend>
               <div className="space-y-2 mt-1">
-                {WEBHOOK_EVENTS.map((evt) => (
-                  <label key={evt} className="flex items-center gap-2 text-sm cursor-pointer">
-                    <input type="checkbox" checked={form.events.includes(evt)} onChange={() => toggleEvent(evt)} />
-                    <code className="text-xs">{evt}</code>
-                  </label>
-                ))}
+                {WEBHOOK_EVENTS.map((evt) => {
+                  const id = `webhook-event-${evt}`;
+                  return (
+                    <div key={evt} className="flex items-center gap-2">
+                      <input
+                        id={id}
+                        type="checkbox"
+                        checked={form.events.includes(evt)}
+                        onChange={() => toggleEvent(evt)}
+                      />
+                      <label htmlFor={id} className="text-sm cursor-pointer">
+                        <code className="text-xs">{evt}</code>
+                      </label>
+                    </div>
+                  );
+                })}
               </div>
-            </div>
+            </fieldset>
             <button data-testid="webhook-submit-button" type="submit" disabled={creating} className="btn-primary w-full">
               {creating ? 'Creating...' : 'Create Webhook'}
             </button>

--- a/src/app/waitlist/page.tsx
+++ b/src/app/waitlist/page.tsx
@@ -17,15 +17,19 @@ export default function WaitlistPage() {
   const [form, setForm] = useState({ email: '', username: '', businessName: '', country: '' });
   const [loading, setLoading] = useState(false);
   const [joined, setJoined] = useState(false);
+  const [formError, setFormError] = useState('');
 
   const submit = async (e: React.FormEvent) => {
     e.preventDefault();
+    setFormError('');
     setLoading(true);
     try {
       await waitlistApi.join(form);
       setJoined(true);
     } catch (err) {
-      toast.error(getErrorMessage(err) ?? 'Failed to join waitlist');
+      const msg = getErrorMessage(err) ?? 'Failed to join waitlist';
+      setFormError(msg);
+      toast.error(msg);
     } finally {
       setLoading(false);
     }
@@ -48,6 +52,11 @@ export default function WaitlistPage() {
           </div>
         ) : (
           <form onSubmit={submit} className="space-y-4">
+            {formError && (
+              <p role="alert" className="text-sm text-red-600 bg-red-50 border border-red-200 rounded px-3 py-2">
+                {formError}
+              </p>
+            )}
             <fieldset disabled={loading} className="space-y-4">
               <FormField label="Email" type="email" required value={form.email}
                 onChange={(e) => setForm({ ...form, email: e.target.value })} />


### PR DESCRIPTION
## Summary

Fixes four accessibility issues across the dashboard and auth pages.

> ⚠️ **WARNING: Do not test — implementation only as requested.**

---

### #166 — Webhook event checkboxes: explicit id/htmlFor + fieldset/legend

- Wrapped the events checkbox list in a nested `<fieldset>`/`<legend>` so assistive technology announces it as a related group.
- Added explicit `id` to each checkbox and matching `htmlFor` to each label, replacing the implicit association from wrapping alone.
- Also added `id="webhook-url"` / `htmlFor="webhook-url"` to the Endpoint URL field in the same form.

Closes #166

---

### #165 — Inline persistent error fallback for toast-only feedback

Added a `formError` state + `role="alert"` error banner inside the form (above the submit button) to every form that previously relied on `toast.error` alone as its only error channel:

- `src/app/auth/login/page.tsx`
- `src/app/auth/register/page.tsx`
- `src/app/waitlist/page.tsx`
- `src/app/dashboard/webhooks/page.tsx` (webhook create form)

The toast is still fired; the inline banner is an additional, persistent fallback that stays visible until the next submission attempt.

Closes #165

---

### #163 — Accessible data tables for analytics charts

Added a `className="sr-only"` `<table>` immediately after each Recharts chart in `src/app/dashboard/analytics/page.tsx`:

- **Payment Count by Status** — columns: Status, Count
- **Volume by Status (USD)** — columns: Status, Volume (USD)

Both tables are visually hidden from sighted users but fully accessible to screen readers.

Closes #163

---

### #164 — Labels for admin settlements filter controls

In `src/app/dashboard/admin/settlements/page.tsx`, added `<label htmlFor="…" className="sr-only">` for all four filter inputs:

- `filter-status` → Status select
- `filter-merchant-id` → Merchant ID text input
- `filter-start-date` → Start Date date input
- `filter-end-date` → End Date date input

The `aria-hidden="true"` attribute was also added to the decorative `<Filter>` icon.

Closes #164

---

## What was tested

Not tested per PR instructions.