### PR TITLE
fix: add admin RBAC, security headers, and env validation

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,8 +1,54 @@
 /** @type {import('next').NextConfig} */
+const DEV_API_URL = 'http://localhost:3000/api/v1';
+const isDev = process.env.NODE_ENV !== 'production';
+
+function getApiUrl() {
+  if (process.env.NEXT_PUBLIC_API_URL) return process.env.NEXT_PUBLIC_API_URL;
+  if (isDev) return DEV_API_URL;
+  return undefined;
+}
+
+function getApiOrigin() {
+  try {
+    return new URL(getApiUrl() ?? DEV_API_URL).origin;
+  } catch {
+    return 'http://localhost:3000';
+  }
+}
+
+function buildContentSecurityPolicy() {
+  const apiOrigin = getApiOrigin();
+
+  return [
+    "default-src 'self'",
+    "script-src 'self' 'unsafe-inline' 'unsafe-eval'",
+    "style-src 'self' 'unsafe-inline'",
+    "img-src 'self' data: blob:",
+    "font-src 'self'",
+    `connect-src 'self' ${apiOrigin}`,
+    "frame-ancestors 'none'",
+    "base-uri 'self'",
+    "form-action 'self'",
+  ].join('; ');
+}
+
 const nextConfig = {
   reactStrictMode: true,
   env: {
-    NEXT_PUBLIC_API_URL: process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3000/api/v1',
+    NEXT_PUBLIC_API_URL: getApiUrl(),
+  },
+  async headers() {
+    return [
+      {
+        source: '/:path*',
+        headers: [
+          { key: 'Content-Security-Policy', value: buildContentSecurityPolicy() },
+          { key: 'X-Frame-Options', value: 'DENY' },
+          { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
+          { key: 'X-Content-Type-Options', value: 'nosniff' },
+        ],
+      },
+    ];
   },
   images: {
     // No next/image usage yet, but remote imagery (merchant logos, avatars,

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
+    "prebuild": "node scripts/validate-env.mjs",
     "build": "next build",
     "start": "next start",
     "lint": "next lint",

--- a/scripts/validate-env.mjs
+++ b/scripts/validate-env.mjs
@@ -1,0 +1,9 @@
+const isProduction = process.env.NODE_ENV === 'production';
+
+if (isProduction && !process.env.NEXT_PUBLIC_API_URL) {
+  console.error(
+    '\nBuild failed: NEXT_PUBLIC_API_URL is required for production builds.\n' +
+      'Set it in your environment or .env.production before running `next build`.\n',
+  );
+  process.exit(1);
+}

--- a/src/app/dashboard/admin/layout.tsx
+++ b/src/app/dashboard/admin/layout.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { useAuthStore } from '@/lib/store';
+import { isAdmin } from '@/lib/auth';
+
+export default function AdminLayout({ children }: { children: React.ReactNode }) {
+  const { merchant, token } = useAuthStore();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (!token) {
+      router.replace('/auth/login');
+      return;
+    }
+    if (merchant && !isAdmin(merchant)) {
+      router.replace('/dashboard');
+    }
+  }, [token, merchant, router]);
+
+  if (!merchant || !isAdmin(merchant)) return null;
+
+  return <>{children}</>;
+}

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -13,8 +13,10 @@ import {
   BarChart3,
   Menu,
   X,
+  Shield,
 } from 'lucide-react';
 import { useAuthStore } from '@/lib/store';
+import { isAdmin } from '@/lib/auth';
 import { cn } from '@/lib/utils';
 
 export const metadata = {
@@ -28,6 +30,7 @@ const navItems = [
   { href: '/dashboard/analytics', label: 'Analytics', icon: BarChart3 },
   { href: '/dashboard/webhooks', label: 'Webhooks', icon: Webhook },
   { href: '/dashboard/settings', label: 'Settings', icon: Settings },
+  { href: '/dashboard/admin/settlements', label: 'Admin Settlements', icon: Shield, adminOnly: true },
 ];
 
 export default function DashboardLayout({ children }: { children: React.ReactNode }) {
@@ -46,6 +49,8 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
 
   if (!merchant) return null;
 
+  const visibleNavItems = navItems.filter((item) => !item.adminOnly || isAdmin(merchant));
+
   const sidebarContent = (
     <>
       <div className="p-6 border-b border-gray-100 flex items-center justify-between">
@@ -63,7 +68,7 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
       </div>
 
       <nav className="flex-1 p-4 space-y-1">
-        {navItems.map(({ href, label, icon: Icon, exact }) => {
+        {visibleNavItems.map(({ href, label, icon: Icon, exact }) => {
           const active = exact ? pathname === href : pathname.startsWith(href);
           return (
             <Link

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import { getApiUrl } from './env';
 import type {
   AuthResponse,
   Merchant,
@@ -11,7 +12,7 @@ import type {
 } from './types';
 
 const api = axios.create({
-  baseURL: process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3000/api/v1',
+  baseURL: getApiUrl(),
 });
 
 api.interceptors.request.use((config) => {

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,0 +1,5 @@
+import type { Merchant } from './types';
+
+export function isAdmin(merchant: Merchant | null | undefined): boolean {
+  return merchant?.role === 'admin' || merchant?.role === 'staff';
+}

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -1,0 +1,12 @@
+const DEV_API_URL = 'http://localhost:3000/api/v1';
+
+export function getApiUrl(): string {
+  const url = process.env.NEXT_PUBLIC_API_URL;
+  if (url) return url;
+
+  if (process.env.NODE_ENV === 'development') {
+    return DEV_API_URL;
+  }
+
+  throw new Error('NEXT_PUBLIC_API_URL is not configured');
+}

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -1,12 +1,6 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
-
-interface Merchant {
-  id: string;
-  email: string;
-  businessName: string;
-  status: string;
-}
+import type { Merchant } from './types';
 
 interface AuthState {
   token: string | null;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -6,11 +6,14 @@ export type PaymentStatus =
   | 'failed'
   | 'expired';
 
+export type MerchantRole = 'merchant' | 'admin' | 'staff';
+
 export interface Merchant {
   id: string;
   email: string;
   businessName: string;
   status: string;
+  role?: MerchantRole;
   country?: string;
   bankAccountNumber?: string;
   bankCode?: string;


### PR DESCRIPTION
closes #145
closes #147
closes #151
closes #152

## PR description

### Summary

Closes #145, #147, #151, and #152. Adds frontend role-based access control for the admin settlements route, security headers via Next.js config, and build-time validation for `NEXT_PUBLIC_API_URL`.

---

### #145 / #152 — Admin settlements access control

**Problem:** Any authenticated merchant could visit `/dashboard/admin/settlements` directly. The route was not in navigation and had no role check.

**Changes:**
- Added `role?: MerchantRole` (`'merchant' | 'admin' | 'staff'`) to the `Merchant` type in `src/lib/types.ts`
- Added `src/lib/auth.ts` with `isAdmin()` — returns true for `admin` or `staff`
- Updated `src/lib/store.ts` to use the shared `Merchant` type (role is persisted with auth state)
- Added `src/app/dashboard/admin/layout.tsx` — redirects non-admins to `/dashboard` and unauthenticated users to `/auth/login`
- Updated `src/app/dashboard/layout.tsx` — shows "Admin Settlements" nav item only for admin/staff users

**Secure default:** Merchants without a `role` field (including existing persisted sessions) are treated as non-admin.

**Note:** The backend must return `role` on the merchant object in login/register responses for admins to get access. Frontend enforcement is defense-in-depth; backend must still enforce on `/admin/*` endpoints.

---

### #147 — Security headers

**Problem:** No CSP or other security headers were configured.

**Changes in `next.config.js`:**
- `Content-Security-Policy` — restricts script/style/img/font/connect sources; `connect-src` includes the API origin from `NEXT_PUBLIC_API_URL`
- `X-Frame-Options: DENY` — clickjacking protection
- `Referrer-Policy: strict-origin-when-cross-origin`
- `X-Content-Type-Options: nosniff`

CSP allows `'unsafe-inline'` / `'unsafe-eval'` for scripts, which Next.js 14 still needs without a nonce setup.

---

### #151 — `NEXT_PUBLIC_API_URL` validation

**Problem:** Missing env var silently fell back to `localhost:3000`, causing confusing production failures.

**Changes:**
- Added `scripts/validate-env.mjs` — fails production builds if `NEXT_PUBLIC_API_URL` is unset
- Added `prebuild` script in `package.json` to run validation before `next build`
- Added `src/lib/env.ts` with `getApiUrl()` — localhost fallback only in development; throws in production if unset
- Updated `src/lib/api.ts` and `next.config.js` to use this helper instead of inline fallbacks

---

### Files changed

| File | Change |
|------|--------|
| `src/lib/types.ts` | Added `MerchantRole` and `role` field |
| `src/lib/auth.ts` | New — `isAdmin()` helper |
| `src/lib/store.ts` | Uses shared `Merchant` type |
| `src/lib/env.ts` | New — centralized API URL resolution |
| `src/lib/api.ts` | Uses `getApiUrl()` |
| `src/app/dashboard/admin/layout.tsx` | New — admin route guard |
| `src/app/dashboard/layout.tsx` | Conditional admin nav item |
| `next.config.js` | Security headers + env handling |
| `scripts/validate-env.mjs` | New — build-time env check |
| `package.json` | Added `prebuild` script |

---

### Test plan

- [ ] Log in as a regular merchant → `/dashboard/admin/settlements` redirects to `/dashboard`
- [ ] Regular merchant does not see "Admin Settlements" in the sidebar
- [ ] Log in as admin/staff (backend returns `role: 'admin'` or `'staff'`) → admin route loads and nav item is visible
- [ ] `NODE_ENV=production npm run build` without `NEXT_PUBLIC_API_URL` → build fails with a clear error
- [ ] `NODE_ENV=production NEXT_PUBLIC_API_URL=https://api.example.com/api/v1 npm run build` → build succeeds
- [ ] `npm run dev` without env var → still works with localhost fallback
- [ ] Inspect response headers in browser devtools → CSP, X-Frame-Options, Referrer-Policy, X-Content-Type-Options present