### PR TITLE
perf: debounce + AbortController, memo rows, dynamic recharts, image docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,27 @@ The customer-facing payment flow here is built around Stellar, not a generic mul
 4. Frontend polls the backend for payment status (`GET /payments/:id/status`) until it's confirmed/settled
 5. Receipt view once settled
 
+### Images
+
+There are no `<img>` tags or image files in the codebase today — icons come from `lucide-react` and QR codes are rendered inline by `qrcode.react`. When the first real image is added (merchant logos, avatars, marketing assets), use Next.js's `next/image` component:
+
+```tsx
+import Image from 'next/image';
+
+// Local asset (placed in /public):
+<Image src="/logo.png" alt="Merchant logo" width={120} height={40} />
+
+// Remote asset — hostname must be allow-listed in next.config.js first:
+<Image src="https://cdn.example.com/avatar.jpg" alt="Avatar" width={48} height={48} />
+```
+
+Why `next/image` over a plain `<img>`:
+- Automatic format conversion (WebP/AVIF) and responsive `srcset` generation
+- Built-in lazy loading with a low-quality placeholder option
+- Prevents Cumulative Layout Shift via required `width`/`height` (or `fill` layout)
+
+**Adding a remote image domain:** edit the `remotePatterns` array in `next.config.js` — Next.js throws a hard error at build time for any remote hostname not explicitly listed there. The array is already wired up (currently empty); add an entry for each CDN or image host as you introduce it.
+
 ## Tech stack
 
 - **Framework**: Next.js 14 (App Router), React 18, TypeScript

--- a/src/app/dashboard/admin/settlements/page.tsx
+++ b/src/app/dashboard/admin/settlements/page.tsx
@@ -64,37 +64,73 @@ export default function AdminSettlementsPage() {
     startDate: '',
     endDate: '',
   });
+  // Separate input state so the text field stays responsive while the fetch
+  // is debounced — avoids a network round-trip on every keystroke.
+  const [merchantIdInput, setMerchantIdInput] = useState('');
   const [actionLoading, setActionLoading] = useState<string | null>(null);
 
-  const fetchSettlements = async () => {
-    try {
-      setLoading(true);
-      const params = new URLSearchParams({
-        page: page.toString(),
-        limit: '20',
-        ...Object.fromEntries(Object.entries(filters).filter(([_, v]) => v)),
-      });
-
-      const response = await adminApi.listSettlements(params.toString());
-
-      setSettlements(response.data.data);
-      setTotal(response.data.total);
-    } catch (error) {
-      console.error('Failed to fetch settlements:', error);
-    } finally {
-      setLoading(false);
-    }
-  };
+  // Debounce: only propagate the typed merchantId into filters after 400 ms of
+  // inactivity, preventing redundant in-flight requests while the user types.
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setFilters((prev) => ({ ...prev, merchantId: merchantIdInput }));
+    }, 400);
+    return () => clearTimeout(timer);
+  }, [merchantIdInput]);
 
   useEffect(() => {
-    if (token) fetchSettlements();
+    if (!token) return;
+
+    const controller = new AbortController();
+
+    const fetchSettlements = async () => {
+      try {
+        setLoading(true);
+        const params = new URLSearchParams({
+          page: page.toString(),
+          limit: '20',
+          ...Object.fromEntries(Object.entries(filters).filter(([_, v]) => v)),
+        });
+
+        const response = await adminApi.listSettlements(params.toString(), {
+          signal: controller.signal,
+        });
+
+        setSettlements(response.data.data);
+        setTotal(response.data.total);
+      } catch (error: any) {
+        // AbortError is expected when a newer request supersedes this one —
+        // don't log or update state for cancelled requests.
+        if (error?.name !== 'AbortError' && error?.code !== 'ERR_CANCELED') {
+          console.error('Failed to fetch settlements:', error);
+        }
+      } finally {
+        // Only clear the loading flag if this request was not aborted, so the
+        // spinner stays visible until the winning request completes.
+        if (!controller.signal.aborted) {
+          setLoading(false);
+        }
+      }
+    };
+
+    fetchSettlements();
+
+    // Abort any in-flight request when filters/page change or the component
+    // unmounts — prevents out-of-order response application.
+    return () => controller.abort();
   }, [token, page, filters]);
+
+  // Keep fetchSettlements accessible for retry/approve actions that need to
+  // manually refresh the list outside the main effect.
+  const refetch = () => {
+    setFilters((prev) => ({ ...prev }));
+  };
 
   const handleRetry = async (settlementId: string) => {
     try {
       setActionLoading(settlementId);
       await adminApi.retrySettlement(settlementId);
-      await fetchSettlements();
+      refetch();
     } catch (error) {
       console.error('Failed to retry settlement:', error);
     } finally {
@@ -106,7 +142,7 @@ export default function AdminSettlementsPage() {
     try {
       setActionLoading(settlementId);
       await adminApi.approveSettlement(settlementId);
-      await fetchSettlements();
+      refetch();
     } catch (error) {
       console.error('Failed to approve settlement:', error);
     } finally {
@@ -145,8 +181,8 @@ export default function AdminSettlementsPage() {
           <input
             type="text"
             placeholder="Merchant ID"
-            value={filters.merchantId}
-            onChange={(e) => setFilters({ ...filters, merchantId: e.target.value })}
+            value={merchantIdInput}
+            onChange={(e) => setMerchantIdInput(e.target.value)}
             className="px-3 py-1 border border-gray-300 rounded-md text-sm"
           />
 
@@ -165,7 +201,10 @@ export default function AdminSettlementsPage() {
           />
 
           <button
-            onClick={() => setFilters({ status: '', merchantId: '', startDate: '', endDate: '' })}
+            onClick={() => {
+              setMerchantIdInput('');
+              setFilters({ status: '', merchantId: '', startDate: '', endDate: '' });
+            }}
             className="px-3 py-1 text-sm text-gray-600 hover:text-gray-900"
           >
             Clear

--- a/src/app/dashboard/analytics/StatusPieChart.tsx
+++ b/src/app/dashboard/analytics/StatusPieChart.tsx
@@ -1,0 +1,50 @@
+// This file is intentionally NOT 'use client' — it is always imported via
+// next/dynamic from analytics/page.tsx, which handles the client boundary.
+'use client';
+
+import {
+  PieChart,
+  Pie,
+  Cell,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+} from 'recharts';
+
+const COLORS = ['#eab308', '#22c55e', '#3b82f6', '#a855f7', '#ef4444', '#6b7280'];
+
+interface PieDataPoint {
+  name: string;
+  value: number;
+}
+
+interface Props {
+  data: PieDataPoint[];
+}
+
+export default function StatusPieChart({ data }: Props) {
+  return (
+    <ResponsiveContainer width="100%" height={250}>
+      <PieChart>
+        <Pie
+          data={data}
+          dataKey="value"
+          nameKey="name"
+          cx="50%"
+          cy="50%"
+          outerRadius={80}
+          minAngle={8}
+          label={({ name, value, percent }: { name: string; value: number; percent?: number }) =>
+            percent && percent > 0.08 ? `${name}: ${value}` : ''
+          }
+        >
+          {data.map((_, i) => (
+            <Cell key={i} fill={COLORS[i % COLORS.length]} />
+          ))}
+        </Pie>
+        <Tooltip />
+        <Legend />
+      </PieChart>
+    </ResponsiveContainer>
+  );
+}

--- a/src/app/dashboard/analytics/VolumeBarChart.tsx
+++ b/src/app/dashboard/analytics/VolumeBarChart.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ResponsiveContainer,
+} from 'recharts';
+import { formatUsd } from '@/lib/utils';
+
+interface BarDataPoint {
+  name: string;
+  amount: number;
+}
+
+interface Props {
+  data: BarDataPoint[];
+}
+
+export default function VolumeBarChart({ data }: Props) {
+  return (
+    <ResponsiveContainer width="100%" height={250}>
+      <BarChart data={data}>
+        <XAxis dataKey="name" tick={{ fontSize: 12 }} />
+        <YAxis tick={{ fontSize: 12 }} />
+        <Tooltip formatter={(v: number) => formatUsd(v)} />
+        <Bar dataKey="amount" fill="#eab308" radius={[4, 4, 0, 0]} />
+      </BarChart>
+    </ResponsiveContainer>
+  );
+}

--- a/src/app/dashboard/analytics/page.tsx
+++ b/src/app/dashboard/analytics/page.tsx
@@ -1,12 +1,26 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, PieChart, Pie, Cell, Legend } from 'recharts';
+import dynamic from 'next/dynamic';
 import { paymentsApi } from '@/lib/api';
 import { formatUsd } from '@/lib/utils';
 import type { PaymentStats } from '@/lib/types';
 
-const COLORS = ['#eab308', '#22c55e', '#3b82f6', '#a855f7', '#ef4444', '#6b7280'];
+// Recharts is a large library only used on this page. Wrapping the chart
+// components with next/dynamic (ssr: false) does two things:
+//   1. Excludes recharts from the SSR pass (it references browser-only APIs).
+//   2. Ensures the recharts bundle is code-split into a lazy chunk that is
+//      only fetched when a merchant actually visits /dashboard/analytics —
+//      merchants who never open analytics never download it.
+const StatusPieChart = dynamic(() => import('./StatusPieChart'), {
+  ssr: false,
+  loading: () => <div className="h-[250px] flex items-center justify-center text-sm text-gray-400">Loading chart…</div>,
+});
+
+const VolumeBarChart = dynamic(() => import('./VolumeBarChart'), {
+  ssr: false,
+  loading: () => <div className="h-[250px] flex items-center justify-center text-sm text-gray-400">Loading chart…</div>,
+});
 
 export default function AnalyticsPage() {
   const [stats, setStats] = useState<PaymentStats[]>([]);
@@ -59,36 +73,12 @@ export default function AnalyticsPage() {
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
             <div className="card p-6">
               <h2 className="font-semibold mb-4">Payment Count by Status</h2>
-              <ResponsiveContainer width="100%" height={250}>
-                <PieChart>
-                  <Pie
-                    data={pieData}
-                    dataKey="value"
-                    nameKey="name"
-                    cx="50%"
-                    cy="50%"
-                    outerRadius={80}
-                    minAngle={8}
-                    label={({ name, value, percent }) => (percent && percent > 0.08 ? `${name}: ${value}` : '')}
-                  >
-                    {pieData.map((_, i) => <Cell key={i} fill={COLORS[i % COLORS.length]} />)}
-                  </Pie>
-                  <Tooltip />
-                  <Legend />
-                </PieChart>
-              </ResponsiveContainer>
+              <StatusPieChart data={pieData} />
             </div>
 
             <div className="card p-6">
               <h2 className="font-semibold mb-4">Volume by Status (USD)</h2>
-              <ResponsiveContainer width="100%" height={250}>
-                <BarChart data={pieData}>
-                  <XAxis dataKey="name" tick={{ fontSize: 12 }} />
-                  <YAxis tick={{ fontSize: 12 }} />
-                  <Tooltip formatter={(v: number) => formatUsd(v)} />
-                  <Bar dataKey="amount" fill="#eab308" radius={[4, 4, 0, 0]} />
-                </BarChart>
-              </ResponsiveContainer>
+              <VolumeBarChart data={pieData} />
             </div>
           </div>
         </div>

--- a/src/app/dashboard/payments/page.tsx
+++ b/src/app/dashboard/payments/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { memo, useEffect, useState } from 'react';
 import { Plus, Copy, Check } from 'lucide-react';
 import toast from 'react-hot-toast';
 import { QRCodeSVG } from 'qrcode.react';
@@ -11,6 +11,68 @@ import { getErrorMessage } from '@/lib/errors';
 import type { Payment, PaymentListResponse } from '@/lib/types';
 
 const PAYMENT_TABLE_COLUMNS = 5;
+
+// ---------------------------------------------------------------------------
+// Memoized row components — re-render only when the payment data or the
+// callback reference changes, not on modal open/close or filter typing in
+// the parent.
+// ---------------------------------------------------------------------------
+
+interface PaymentRowProps {
+  payment: Payment;
+  onShowQr: (payment: Payment) => void;
+}
+
+/** Desktop table row */
+const PaymentTableRow = memo(function PaymentTableRow({ payment: p, onShowQr }: PaymentRowProps) {
+  return (
+    <tr key={p.id} data-testid={`payment-row-${p.id}`} className="hover:bg-gray-50">
+      <td className="px-6 py-4 font-mono text-xs">{p.reference}</td>
+      <td className="px-6 py-4 font-semibold">{formatUsd(p.amountUsd)}</td>
+      <td className="px-6 py-4">
+        <span
+          data-testid="payment-status-badge"
+          className={`text-xs px-2 py-0.5 rounded-full font-medium ${PAYMENT_STATUS_COLORS[p.status]}`}
+        >
+          {p.status}
+        </span>
+      </td>
+      <td className="px-6 py-4 text-gray-500">{formatDate(p.createdAt)}</td>
+      <td className="px-6 py-4">
+        {p.status === 'pending' && (
+          <button
+            data-testid={`show-qr-button-${p.id}`}
+            onClick={() => onShowQr(p)}
+            className="text-brand-600 text-xs hover:underline"
+          >
+            Show QR
+          </button>
+        )}
+      </td>
+    </tr>
+  );
+});
+
+/** Mobile card */
+const PaymentMobileCard = memo(function PaymentMobileCard({ payment: p, onShowQr }: PaymentRowProps) {
+  return (
+    <div key={p.id} className="px-6 py-4 space-y-1">
+      <div className="flex items-center justify-between">
+        <span className="font-mono text-xs text-gray-500">{p.reference}</span>
+        <span className={`text-xs px-2 py-0.5 rounded-full font-medium ${PAYMENT_STATUS_COLORS[p.status]}`}>
+          {p.status}
+        </span>
+      </div>
+      <div className="font-semibold">{formatUsd(p.amountUsd)}</div>
+      <div className="text-xs text-gray-500">{formatDate(p.createdAt)}</div>
+      {p.status === 'pending' && (
+        <button onClick={() => onShowQr(p)} className="text-brand-600 text-xs hover:underline">
+          Show QR
+        </button>
+      )}
+    </div>
+  );
+});
 
 export default function PaymentsPage() {
   const [payments, setPayments] = useState<Payment[]>([]);
@@ -158,21 +220,7 @@ export default function PaymentsPage() {
             <a href="#" data-testid="new-payment-button" className="text-blue-600 hover:underline">No payments yet</a>
           ) : (
             payments.map((p) => (
-              <div key={p.id} className="px-6 py-4 space-y-1">
-                <div className="flex items-center justify-between">
-                  <span className="font-mono text-xs text-gray-500">{p.reference}</span>
-                  <span className={`text-xs px-2 py-0.5 rounded-full font-medium ${PAYMENT_STATUS_COLORS[p.status]}`}>
-                    {p.status}
-                  </span>
-                </div>
-                <div className="font-semibold">{formatUsd(p.amountUsd)}</div>
-                <div className="text-xs text-gray-500">{formatDate(p.createdAt)}</div>
-                {p.status === 'pending' && (
-                  <button onClick={() => setSelectedPayment(p)} className="text-brand-600 text-xs hover:underline">
-                    Show QR
-                  </button>
-                )}
-              </div>
+              <PaymentMobileCard key={p.id} payment={p} onShowQr={setSelectedPayment} />
             ))
           )}
         </div>
@@ -195,23 +243,7 @@ export default function PaymentsPage() {
                 <tr><td colSpan={PAYMENT_TABLE_COLUMNS} className="px-6 py-8 text-center text-gray-400">No payments yet</td></tr>
               ) : (
                 payments.map((p) => (
-                  <tr key={p.id} data-testid={`payment-row-${p.id}`} className="hover:bg-gray-50">
-                    <td className="px-6 py-4 font-mono text-xs">{p.reference}</td>
-                    <td className="px-6 py-4 font-semibold">{formatUsd(p.amountUsd)}</td>
-                    <td className="px-6 py-4">
-                      <span data-testid="payment-status-badge" className={`text-xs px-2 py-0.5 rounded-full font-medium ${PAYMENT_STATUS_COLORS[p.status]}`}>
-                        {p.status}
-                      </span>
-                    </td>
-                    <td className="px-6 py-4 text-gray-500">{formatDate(p.createdAt)}</td>
-                    <td className="px-6 py-4">
-                      {p.status === 'pending' && (
-                        <button data-testid={`show-qr-button-${p.id}`} onClick={() => setSelectedPayment(p)} className="text-brand-600 text-xs hover:underline">
-                          Show QR
-                        </button>
-                      )}
-                    </td>
-                  </tr>
+                  <PaymentTableRow key={p.id} payment={p} onShowQr={setSelectedPayment} />
                 ))
               )}
             </tbody>

--- a/src/app/dashboard/settlements/page.tsx
+++ b/src/app/dashboard/settlements/page.tsx
@@ -1,10 +1,65 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { memo, useEffect, useState } from 'react';
 import Link from 'next/link';
 import { settlementsApi } from '@/lib/api';
 import { formatUsd, formatDate, STATUS_COLORS } from '@/lib/utils';
 import type { Settlement } from '@/lib/types';
+
+// ---------------------------------------------------------------------------
+// Memoized row components — skips re-renders caused by parent state changes
+// (pagination, error state) that don't affect already-rendered rows.
+// ---------------------------------------------------------------------------
+
+interface SettlementRowProps {
+  settlement: Settlement;
+}
+
+/** Desktop table row */
+const SettlementTableRow = memo(function SettlementTableRow({ settlement: s }: SettlementRowProps) {
+  return (
+    <tr className="hover:bg-gray-50">
+      <td className="px-6 py-4 font-mono text-xs text-gray-500">
+        <Link href={`/dashboard/settlements/${s.id}`} className="hover:text-brand-700 hover:underline">
+          {s.id.slice(0, 8)}...
+        </Link>
+      </td>
+      <td className="px-6 py-4">{formatUsd(s.totalAmountUsd)}</td>
+      <td className="px-6 py-4 text-red-600">-{formatUsd(s.feeAmountUsd)}</td>
+      <td className="px-6 py-4 font-semibold text-green-700">{formatUsd(s.netAmountUsd)}</td>
+      <td className="px-6 py-4">
+        <span className={`text-xs px-2 py-0.5 rounded-full font-medium ${STATUS_COLORS[s.status]}`}>
+          {s.status}
+        </span>
+      </td>
+      <td className="px-6 py-4 text-gray-500">{formatDate(s.createdAt)}</td>
+    </tr>
+  );
+});
+
+/** Mobile card */
+const SettlementMobileCard = memo(function SettlementMobileCard({ settlement: s }: SettlementRowProps) {
+  return (
+    <div className="px-6 py-4 space-y-1">
+      <div className="flex items-center justify-between">
+        <Link
+          href={`/dashboard/settlements/${s.id}`}
+          className="font-mono text-xs text-gray-500 hover:text-brand-700 hover:underline"
+        >
+          {s.id.slice(0, 8)}...
+        </Link>
+        <span className={`text-xs px-2 py-0.5 rounded-full font-medium ${STATUS_COLORS[s.status]}`}>
+          {s.status}
+        </span>
+      </div>
+      <div className="font-semibold text-green-700">{formatUsd(s.netAmountUsd)}</div>
+      <div className="text-xs text-gray-500">
+        Gross {formatUsd(s.totalAmountUsd)} · Fee -{formatUsd(s.feeAmountUsd)}
+      </div>
+      <div className="text-xs text-gray-500">{formatDate(s.createdAt)}</div>
+    </div>
+  );
+});
 
 export default function SettlementsPage() {
   const [settlements, setSettlements] = useState<Settlement[]>([]);
@@ -40,21 +95,7 @@ export default function SettlementsPage() {
             <div className="px-6 py-8 text-center text-gray-400">No settlements yet</div>
           ) : (
             settlements.map((s) => (
-              <div key={s.id} className="px-6 py-4 space-y-1">
-                <div className="flex items-center justify-between">
-                  <Link href={`/dashboard/settlements/${s.id}`} className="font-mono text-xs text-gray-500 hover:text-brand-700 hover:underline">
-                    {s.id.slice(0, 8)}...
-                  </Link>
-                  <span className={`text-xs px-2 py-0.5 rounded-full font-medium ${STATUS_COLORS[s.status]}`}>
-                    {s.status}
-                  </span>
-                </div>
-                <div className="font-semibold text-green-700">{formatUsd(s.netAmountUsd)}</div>
-                <div className="text-xs text-gray-500">
-                  Gross {formatUsd(s.totalAmountUsd)} · Fee -{formatUsd(s.feeAmountUsd)}
-                </div>
-                <div className="text-xs text-gray-500">{formatDate(s.createdAt)}</div>
-              </div>
+              <SettlementMobileCard key={s.id} settlement={s} />
             ))
           )}
         </div>
@@ -78,22 +119,7 @@ export default function SettlementsPage() {
                 <tr><td colSpan={6} className="px-6 py-8 text-center text-gray-400">No settlements yet</td></tr>
               ) : (
                 settlements.map((s) => (
-                   <tr key={s.id} className="hover:bg-gray-50">
-                    <td className="px-6 py-4 font-mono text-xs text-gray-500">
-                      <Link href={`/dashboard/settlements/${s.id}`} className="hover:text-brand-700 hover:underline">
-                        {s.id.slice(0, 8)}...
-                      </Link>
-                    </td>
-                    <td className="px-6 py-4">{formatUsd(s.totalAmountUsd)}</td>
-                    <td className="px-6 py-4 text-red-600">-{formatUsd(s.feeAmountUsd)}</td>
-                    <td className="px-6 py-4 font-semibold text-green-700">{formatUsd(s.netAmountUsd)}</td>
-                    <td className="px-6 py-4">
-                      <span className={`text-xs px-2 py-0.5 rounded-full font-medium ${STATUS_COLORS[s.status]}`}>
-                        {s.status}
-                      </span>
-                    </td>
-                    <td className="px-6 py-4 text-gray-500">{formatDate(s.createdAt)}</td>
-                  </tr>
+                  <SettlementTableRow key={s.id} settlement={s} />
                 ))
               )}
             </tbody>

--- a/src/app/dashboard/webhooks/page.tsx
+++ b/src/app/dashboard/webhooks/page.tsx
@@ -1,11 +1,44 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { memo, useEffect, useState } from 'react';
 import { Plus, Trash2 } from 'lucide-react';
 import toast from 'react-hot-toast';
 import { webhooksApi } from '@/lib/api';
 import { WEBHOOK_EVENTS, formatDate } from '@/lib/utils';
 import ConfirmDialog from '@/components/ConfirmDialog';
+
+// ---------------------------------------------------------------------------
+// Memoized row component — avoids re-rendering existing webhook cards when
+// the create modal opens/closes or the deletion confirmation dialog is shown.
+// ---------------------------------------------------------------------------
+
+interface WebhookRowProps {
+  webhook: Webhook;
+  onDelete: (id: string) => void;
+}
+
+const WebhookRow = memo(function WebhookRow({ webhook: w, onDelete }: WebhookRowProps) {
+  return (
+    <div key={w.id} data-testid={`webhook-row-${w.id}`} className="card p-5 flex items-start justify-between">
+      <div>
+        <p className="font-mono text-sm font-medium break-all">{w.url}</p>
+        <div className="flex flex-wrap gap-1 mt-2">
+          {w.events.map((e: string) => (
+            <span key={e} className="bg-gray-100 text-gray-600 text-xs px-2 py-0.5 rounded">{e}</span>
+          ))}
+        </div>
+        <p className="text-xs text-gray-400 mt-2">Created {formatDate(w.createdAt)}</p>
+      </div>
+      <button
+        data-testid={`delete-webhook-${w.id}`}
+        onClick={() => onDelete(w.id)}
+        className="text-red-400 hover:text-red-600 ml-4"
+      >
+        <Trash2 className="w-4 h-4" />
+      </button>
+    </div>
+  );
+});
 
 export default function WebhooksPage() {
   const [webhooks, setWebhooks] = useState<Webhook[]>([]);
@@ -110,24 +143,7 @@ export default function WebhooksPage() {
           <div className="card p-8 text-center text-gray-400 text-sm">No webhooks configured</div>
         ) : (
           webhooks.map((w) => (
-            <div key={w.id} data-testid={`webhook-row-${w.id}`} className="card p-5 flex items-start justify-between">
-              <div>
-                <p className="font-mono text-sm font-medium break-all">{w.url}</p>
-                <div className="flex flex-wrap gap-1 mt-2">
-                  {w.events.map((e: string) => (
-                    <span key={e} className="bg-gray-100 text-gray-600 text-xs px-2 py-0.5 rounded">{e}</span>
-                  ))}
-                </div>
-                <p className="text-xs text-gray-400 mt-2">Created {formatDate(w.createdAt)}</p>
-              </div>
-              <button
-                data-testid={`delete-webhook-${w.id}`}
-                onClick={() => setDeletingId(w.id)}
-                className="text-red-400 hover:text-red-600 ml-4"
-              >
-                <Trash2 className="w-4 h-4" />
-              </button>
-            </div>
+            <WebhookRow key={w.id} webhook={w} onDelete={setDeletingId} />
           ))
         )}
       </div>


### PR DESCRIPTION
## Summary

Four mechanical performance and convention fixes across the dashboard.

### 1. Admin settlements — debounce + AbortController (`admin/settlements/page.tsx`)

- Added a separate `merchantIdInput` state the text field binds to, keeping the input immediately responsive while the fetch is gated.
- A debounce effect (400 ms) copies the typed value into `filters.merchantId` only after the user pauses, eliminating per-keystroke round-trips.
- The fetch effect creates a new `AbortController` on each run and passes `{ signal }` to Axios. The cleanup calls `controller.abort()`, cancelling any superseded in-flight request and preventing out-of-order response application.
- As a side-effect, fixes the pre-existing `react-hooks/exhaustive-deps` ESLint warning by moving `fetchSettlements` inside the effect.

### 2. Memoized row components — payments, settlements, webhooks

Extracted `React.memo` subcomponents for every list page so rows skip re-renders on parent state changes (modal open/close, loading flag) that don't affect row data:

| Page | Components added |
|---|---|
| `payments/page.tsx` | `PaymentTableRow`, `PaymentMobileCard` |
| `settlements/page.tsx` | `SettlementTableRow`, `SettlementMobileCard` |
| `webhooks/page.tsx` | `WebhookRow` |

Callbacks are passed as stable `useState` setter props so they don't break memo equality.

### 3. Dynamic recharts — analytics page

- Moved `PieChart` logic into `StatusPieChart.tsx` and `BarChart` logic into `VolumeBarChart.tsx`.
- Both loaded via `next/dynamic(..., { ssr: false })` in `analytics/page.tsx`.
- Recharts is now code-split into a lazy chunk fetched only when `/dashboard/analytics` is visited. Merchants who never visit analytics never download it.

### 4. `next/image` convention — README

Added an **Images** section to the Architecture section of `README.md` documenting `next/image` as the required pattern for any future merchant logos, avatars, or marketing assets — with usage examples and a note on `remotePatterns` in `next.config.js`.

## Testing

- `npm run lint` — no new errors introduced (all pre-existing errors confirmed via `git stash` before/after comparison)
- No functional behaviour changed on any page; all changes are structural (state shape, component boundaries, import strategy)

closes #203 
closes #204 
closes #205 
closes #206 