### PR TITLE
test(pay-page): add polling timer tests

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,0 +1,21 @@
+import type { Config } from 'jest';
+
+const config: Config = {
+  testEnvironment: 'jsdom',
+  transform: {
+    '^.+\\.(ts|tsx)$': ['ts-jest', {
+      tsconfig: {
+        jsx: 'react-jsx',
+      },
+    }],
+  },
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/src/$1',
+    '\\.(css|less|scss|sass)$': 'identity-obj-proxy',
+    '\\.(svg|png|jpg|jpeg|gif|webp)$': '<rootDir>/src/__mocks__/fileMock.ts',
+  },
+  testMatch: ['**/__tests__/**/*.test.(ts|tsx)', '**/*.test.(ts|tsx)'],
+  setupFilesAfterEnv: ['<rootDir>/src/setupTests.ts'],
+};
+
+export default config;

--- a/package.json
+++ b/package.json
@@ -7,7 +7,10 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "type-check": "tsc --noEmit"
+    "type-check": "tsc --noEmit",
+    "test": "jest",
+    "test:watch": "jest --watch",
+    "test:coverage": "jest --coverage"
   },
   "dependencies": {
     "next": "14.2.5",
@@ -25,14 +28,21 @@
     "date-fns": "^3.6.0"
   },
   "devDependencies": {
+    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/react": "^16.3.0",
+    "@testing-library/user-event": "^14.6.1",
     "@types/node": "^20",
     "@types/react": "^18",
     "@types/react-dom": "^18",
     "autoprefixer": "^10.0.1",
     "eslint": "^8",
     "eslint-config-next": "14.2.5",
+    "identity-obj-proxy": "^3.0.0",
+    "jest": "^29.7.0",
+    "jest-environment-jsdom": "^29.7.0",
     "postcss": "^8",
     "tailwindcss": "^3.4.1",
+    "ts-jest": "^29.4.0",
     "typescript": "^5"
   }
 }

--- a/src/__mocks__/fileMock.ts
+++ b/src/__mocks__/fileMock.ts
@@ -1,0 +1,2 @@
+const fileMock = 'test-file-stub';
+export default fileMock;

--- a/src/__mocks__/next/link.tsx
+++ b/src/__mocks__/next/link.tsx
@@ -1,0 +1,6 @@
+import React from 'react';
+
+const Link = ({ children, href, ...props }: { children: React.ReactNode; href: string; [key: string]: unknown }) =>
+  React.createElement('a', { href, ...props }, children);
+
+export default Link;

--- a/src/__mocks__/next/navigation.ts
+++ b/src/__mocks__/next/navigation.ts
@@ -1,0 +1,12 @@
+const useRouter = jest.fn(() => ({
+  push: jest.fn(),
+  replace: jest.fn(),
+  prefetch: jest.fn(),
+  back: jest.fn(),
+}));
+
+const usePathname = jest.fn(() => '/dashboard');
+const useSearchParams = jest.fn(() => new URLSearchParams());
+const redirect = jest.fn();
+
+module.exports = { useRouter, usePathname, useSearchParams, redirect };

--- a/src/__mocks__/qrcode.react.tsx
+++ b/src/__mocks__/qrcode.react.tsx
@@ -1,0 +1,4 @@
+import React from 'react';
+
+export const QRCodeSVG = ({ value }: { value: string }) =>
+  React.createElement('div', { 'data-testid': 'qrcode', 'data-value': value });

--- a/src/__tests__/pay-page-polling.test.tsx
+++ b/src/__tests__/pay-page-polling.test.tsx
@@ -1,0 +1,145 @@
+/**
+ * Tests for /pay/[paymentId] polling timer logic
+ * Issue: interval fires every 5s, cleared on unmount, cleared on terminal status
+ */
+import React from 'react';
+import { render, act, waitFor } from '@testing-library/react';
+import { paymentsApi } from '@/lib/api';
+import PayPage from '@/app/pay/[paymentId]/page';
+
+jest.mock('@/lib/api', () => ({
+  paymentsApi: {
+    getByReference: jest.fn(),
+  },
+}));
+
+jest.mock('qrcode.react', () => ({
+  QRCodeSVG: () => <div data-testid="qrcode" />,
+}));
+
+const mockGetByReference = paymentsApi.getByReference as jest.MockedFunction<typeof paymentsApi.getByReference>;
+
+const PENDING_PAYMENT = {
+  id: 'pay-001',
+  reference: 'REF-001',
+  amountUsd: 10,
+  amountXlm: 25,
+  status: 'pending' as const,
+  stellarMemo: 'MEMO',
+  stellarDepositAddress: 'GADDR',
+  createdAt: new Date().toISOString(),
+};
+
+const defaultParams = { paymentId: 'REF-001' };
+
+beforeEach(() => {
+  jest.useFakeTimers();
+  jest.clearAllMocks();
+});
+
+afterEach(() => {
+  jest.runOnlyPendingTimers();
+  jest.useRealTimers();
+});
+
+describe('PayPage — polling timer logic', () => {
+  it('calls getByReference once on mount (initial fetch)', async () => {
+    mockGetByReference.mockResolvedValue({ data: PENDING_PAYMENT } as ReturnType<typeof paymentsApi.getByReference>);
+
+    render(<PayPage params={defaultParams} />);
+
+    // Flush the initial fetch
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    // Initial fetch call
+    expect(mockGetByReference).toHaveBeenCalledTimes(1);
+  });
+
+  it('fires the poll interval every 5000ms', async () => {
+    mockGetByReference.mockResolvedValue({ data: PENDING_PAYMENT } as ReturnType<typeof paymentsApi.getByReference>);
+
+    render(<PayPage params={defaultParams} />);
+
+    // Flush initial fetch
+    await act(async () => { await Promise.resolve(); });
+    const afterMount = mockGetByReference.mock.calls.length; // 1
+
+    // Advance 5s → 1 poll tick
+    await act(async () => {
+      jest.advanceTimersByTime(5000);
+      await Promise.resolve();
+    });
+    expect(mockGetByReference.mock.calls.length).toBe(afterMount + 1);
+
+    // Advance another 5s → 2nd poll tick
+    await act(async () => {
+      jest.advanceTimersByTime(5000);
+      await Promise.resolve();
+    });
+    expect(mockGetByReference.mock.calls.length).toBe(afterMount + 2);
+  });
+
+  it('clears the interval on unmount', async () => {
+    mockGetByReference.mockResolvedValue({ data: PENDING_PAYMENT } as ReturnType<typeof paymentsApi.getByReference>);
+
+    const { unmount } = render(<PayPage params={defaultParams} />);
+
+    // Flush initial fetch
+    await act(async () => { await Promise.resolve(); });
+    const afterMount = mockGetByReference.mock.calls.length;
+
+    // Advance 5s to confirm polling is running
+    await act(async () => {
+      jest.advanceTimersByTime(5000);
+      await Promise.resolve();
+    });
+    expect(mockGetByReference.mock.calls.length).toBe(afterMount + 1);
+
+    // Unmount — interval should be cleared
+    unmount();
+
+    // Advance more time — no additional calls should happen
+    await act(async () => {
+      jest.advanceTimersByTime(15000);
+      await Promise.resolve();
+    });
+    expect(mockGetByReference.mock.calls.length).toBe(afterMount + 1);
+  });
+
+  it.each(['settled', 'failed', 'expired'] as const)(
+    'stops polling when status becomes terminal: %s',
+    async (terminalStatus) => {
+      // First call (initial): returns pending
+      // Second call (first poll tick): returns terminal status
+      mockGetByReference
+        .mockResolvedValueOnce({ data: PENDING_PAYMENT } as ReturnType<typeof paymentsApi.getByReference>)
+        .mockResolvedValue({
+          data: { ...PENDING_PAYMENT, status: terminalStatus },
+        } as ReturnType<typeof paymentsApi.getByReference>);
+
+      render(<PayPage params={defaultParams} />);
+
+      // Flush initial fetch
+      await act(async () => { await Promise.resolve(); });
+
+      // First poll tick → triggers terminal status → clears interval
+      await act(async () => {
+        jest.advanceTimersByTime(5000);
+        await Promise.resolve();
+        await Promise.resolve(); // flush the .then()
+      });
+
+      const callsAfterTerminal = mockGetByReference.mock.calls.length;
+
+      // Advance much further — no new calls expected
+      await act(async () => {
+        jest.advanceTimersByTime(30000);
+        await Promise.resolve();
+      });
+
+      expect(mockGetByReference.mock.calls.length).toBe(callsAfterTerminal);
+    },
+  );
+});

--- a/src/app/pay/[paymentId]/page.tsx
+++ b/src/app/pay/[paymentId]/page.tsx
@@ -7,16 +7,6 @@ import { paymentsApi } from '@/lib/api';
 import { formatUsd } from '@/lib/utils';
 import type { Payment } from '@/lib/types';
 
-interface Payment {
-  amountUsd: number;
-  amountXlm: number | string;
-  description?: string;
-  reference: string;
-  status: string;
-  stellarDepositAddress: string;
-  stellarMemo: string;
-}
-
 export async function generateMetadata({ params }: { params: { paymentId: string } }) {
   try {
     const { data } = await paymentsApi.getByReference(params.paymentId);
@@ -34,6 +24,8 @@ const STATUS_ICONS: Record<string, React.ReactNode> = {
   failed: <XCircle className="w-8 h-8 text-red-500" />,
   expired: <XCircle className="w-8 h-8 text-gray-400" />,
 };
+
+const DEFAULT_STATUS_ICON = <Loader2 className="w-8 h-8 text-gray-400 animate-spin" />;
 
 function computeExpiresAt(payment: any): Date | null {
   if (payment?.expiresAt) return new Date(payment.expiresAt);
@@ -56,10 +48,11 @@ export default function PayPage({ params }: { params: { paymentId: string } }) {
   const [loading, setLoading] = useState(true);
   const [now, setNow] = useState(Date.now());
   const [copied, setCopied] = useState<string | null>(null);
+  const [pollWarning, setPollWarning] = useState<string>('');
 
   useEffect(() => {
     let pollAttempts = 0;
-    paymentsApi.getByReference(params.paymentId).then(({ data }) => setPayment(data)).finally(() => setLoading(false));
+    paymentsApi.getByReference(params.paymentId).then(({ data }) => setPayment(data)).catch(() => { /* shows "Payment not found" */ }).finally(() => setLoading(false));
 
     const interval = setInterval(() => {
       pollAttempts += 1;

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';


### PR DESCRIPTION
- Install Jest + Testing Library infrastructure
- Fix pay page source: add missing setPollWarning state, DEFAULT_STATUS_ICON constant, remove duplicate Payment interface, add .catch() to initial fetch
- Tests: interval fires every 5000ms; cleared on unmount; cleared on terminal status (settled/failed/expired)

closes #137 